### PR TITLE
2.5rc2

### DIFF
--- a/docs/_layouts/landing.html
+++ b/docs/_layouts/landing.html
@@ -183,12 +183,11 @@ table.steelBlueCols tfoot .links a{
         <div class="grid" style="background-color: #2d2d2d">
           <div class="cell cell--12 cell--lg-12" style="text-align: left; background-color: #2d2d2d; padding: 10px">
             {% highlight bash %}
-# Install Spark NLP from PyPI
-pip install nlu==2.5rc1
+# Install NLU from PyPI
+pip install nlu
 
-# Install Spark NLP from Anaconda/Conda
-conda install -c johnsnowlabs nlu==2.5rc1
-
+# Install NLU from Anaconda/Conda
+conda install -c johnsnowlabs nlu
             {% endhighlight %}
           </div>
         </div>
@@ -427,20 +426,20 @@ conda install -c johnsnowlabs nlu==2.5rc1
 <section class="hero hero--center" id="hero-3" style="background-image: url(/);"><div class="hero__content">
   <div class="mb-5">
 
-    <h1>Right Out of The Box</h1><p>NLU ships with many <b>NLP features</b>, pre-trained <b>models</b> and <b>pipelines</b> <br> It takes in Pandas and outputs <b> Pandas Dataframes </b> <br>  All in <u> <b> one line <b> </b></b></u></p><ul class="menu"><li><b><b><a class="button button--outline-info button--pill button--lg" href="/docs/en/pipelines">Pipelines</a>
-  </b></b></li><li><b><b><a class="button button--outline-info button--pill button--lg" href="docs/en/models">Models</a>
-  </b></b></li><li><b><b><a class="button button--outline-info button--pill button--lg" href="docs/en/models">Models</a>
-  </b></b></li><li><b><b><a class="button button--outline-info button--pill button--lg" href="tokenization">Tokenization</a>
-  </b></b></li><li><b><b><a class="button button--outline-info button--pill button--lg" href="stemmer">Stemming</a>
-  </b></b></li><li><b><b><a class="button button--outline-info button--pill button--lg" href="stopwords-removal">Stopwords removal</a>
-  </b></b></li><li><b><b><a class="button button--outline-info button--pill button--lg" href="part-of-speech--pos">Part-of-Speech (POS)</a>
-  </b></b></li><li><b><b><a class="button button--outline-info button--pill button--lg" href="multi-class-emotion-detection">Multi Class Emotion detection</a>
-  </b></b></li><li><b><b><a class="button button--outline-info button--pill button--lg" href="sentiment">Sentiment detection</a>
-  </b></b></li><li><b><b><a class="button button--outline-info button--pill button--lg" href="spellchecking">Spell checking</a>
-  </b></b></li><li><b><b><a class="button button--outline-info button--pill button--lg" href="lemmatization">Lemmatization</a>
-  </b></b></li><li><b><b><a class="button button--outline-info button--pill button--lg" href="normalizers">Normalization</a>
-  </b></b></li><li><b><b><a class="button button--outline-info button--pill button--lg" href="language-classification">Language Classification</a>
-  </b></b></li><li><b><b><a class="button button--outline-info button--pill button--lg" href="named-entity-recognition--ner-">Named Entity Recognition (NER)</a>
+    <h1>Right Out of The Box</h1><p>NLU ships with many <b>NLP features</b>, pre-trained <b>models</b> and <b>pipelines</b> <br> It takes in Pandas and outputs <b> Pandas Dataframes </b> <br>  All in <u> <b> one line <b> </b></b></u></p>
+    <ul class="menu">
+  </b></b></li><li><b><b><a class="button button--outline-info button--pill button--lg" href="docs/en/namespace">Models and Pipelines</a>
+  </b></b></li><li><b><b><a class="button button--outline-info button--pill button--lg" href="#tokenization">Tokenization</a>
+  </b></b></li><li><b><b><a class="button button--outline-info button--pill button--lg" href="#stemmer">Stemming</a>
+  </b></b></li><li><b><b><a class="button button--outline-info button--pill button--lg" href="#stopwords-removal">Stopwords removal</a>
+  </b></b></li><li><b><b><a class="button button--outline-info button--pill button--lg" href="#part-of-speech--pos">Part-of-Speech (POS)</a>
+  </b></b></li><li><b><b><a class="button button--outline-info button--pill button--lg" href="#multi-class-emotion-detection">Multi Class Emotion detection</a>
+  </b></b></li><li><b><b><a class="button button--outline-info button--pill button--lg" href="#sentiment">Sentiment detection</a>
+  </b></b></li><li><b><b><a class="button button--outline-info button--pill button--lg" href="#spellchecking">Spell checking</a>
+  </b></b></li><li><b><b><a class="button button--outline-info button--pill button--lg" href="#lemmatization">Lemmatization</a>
+  </b></b></li><li><b><b><a class="button button--outline-info button--pill button--lg" href="#normalizers">Normalization</a>
+  </b></b></li><li><b><b><a class="button button--outline-info button--pill button--lg" href="#language-classification">Language Classification</a>
+  </b></b></li><li><b><b><a class="button button--outline-info button--pill button--lg" href="#named-entity-recognition-ner">Named Entity Recognition (NER)</a>
   </b></b></li><li><b><b><a class="button button--outline-info button--pill button--lg" href="#ngrams">NGrams</a>
   </b></b></li><li><b><b><a class="button button--outline-info button--pill button--lg" href="#regex-matching">Regex Matching</a>
   </b></b></li><li><b><b><a class="button button--outline-info button--pill button--lg" href="#text-matching">Text Matching</a>

--- a/docs/en/examples.md
+++ b/docs/en/examples.md
@@ -103,10 +103,10 @@ nlu.load('emotion').predict('I love NLU!')
 
 {:.steelBlueCols}
 
-|sentence_embeddings	|category_sentence	|category_surprise	|category_sadness	|category_joy|	category_fear	|sentence	|category	|id|
-|-----------------------|-------------------|-------------------|-------------------|------------|------------------|-----------|----------|----|
-|[0.027570432052016258, -0.052647676318883896, ...] | 0	| 0.012899903	| 0.0015578865	| 0.9760173	|0.0095249	| I love NLU!	| joy	|1|
 
+|sentence_embeddings| 	category_confidence| 	sentence| 	category| 	id|
+|--------------------|---------------------|------------|------------|-----|
+|[0.027570432052016258, -0.052647676318883896, ...]	|0.976017	|I love NLU!	|joy	|1|
 
 ## Sentiment
 ```python
@@ -183,10 +183,12 @@ nlu.load('lang').predict(['NLU is an open-source text processing library for adv
 ```
 
 {:.steelBlueCols}
-|language_de | 	language_no | 	language_ru | 	language_sv | 	language_fi | 	language_pt | 	language_bg | 	language_el | 	language_en | 	language_hr | 	language_it | 	language_fr | 	language_hu | 	language_es| 	language_cs | 	language_uk | 	language_sk | 	language_pl | 	language_ro| 	language_tr| 	document|	language|	id|
-|------------|--------------|----------------|-------------|----------------|--------------|-----------------|---------------|--------------|---------------|----------------|--------------|---------------|--------------|----------------|---------------|----------------|---------------|-------------|-----------------|-----------|----------|------|
-|1.10927795E-4	|1.786265E-4 | 	3.09676E-5 | 	0.005297283	| 1.085274E-5	 | 4.7062217E-6| 	6.4429906E-7| 	0.0011827932|	0.9854069	|1.6956832E-6 | 1.4030554E-5 | 	1.466399E-4 | 	3.2495E-6 | 0.007108454	| 8.250847E-5 | 	1.2385209E-4 | 	2.4604517E-6 | 	1.9354234E-4 | 	1.2024728E-5 | 	8.7725675E-5 | 	NLU is an open-source text processing library ... | 	en	| 0| 
-|2.9392602E-6	|3.7423422E-5 | 1.5859371E-6 | 	4.2966826E-6 | 	2.0913217E-6 | 	3.0820165E-6 | 	3.3508215E-7 | 	8.960027E-8	| 2.0083774E-6	| 4.2742064E-7	| 4.701018E-5 | 	0.9998223	| 6.3511393E-6	| 6.6381785E-5	| 8.5110266E-8 | 	1.8988333E-6	| 1.6178213E-8	| 3.8753042E-10	| 9.3351207E-7	| 6.692207E-7	| NLU est une bibliothèque de traitement de text...	|fr	|1| 
+
+|language_confidence|	document| 	language|	id|
+|------------------|-----------|-------------|------|
+|0.985407	|NLU is an open-source text processing library ...]|	en|	0|
+|0.999822	|NLU est une bibliothèque de traitement de text...]|	fr|	1|
+
 
 ## Named Entity Recognition (NER)
 ```python
@@ -524,9 +526,10 @@ nlu.load('en.classify.fakenews').predict('Unicorns have been sighted on Mars!')
 ```
 
 {:.steelBlueCols}
-| sentence_embeddings | 	category_sentence  | 	category_REAL | 	category_FAKE| 	sentence | 	category | 	id| 
-|--------------------|--------------------------|----------------|-------------------|-----------|-----------|-----|
-|[-0.01756167598068714, 0.015006818808615208, -...]	| 0	| 3.1013436E-16	| 1.0	| Unicorns have been sighted on Mars!	|FAKE	|1|
+|sentence_embeddings|	category_confidence| 	sentence| 	category| 	id| 
+|------------------|-----------------------|------------|-----------|------|
+|[-0.01756167598068714, 0.015006818808615208, -...]	| 1.000000	| Unicorns have been sighted on Mars!	|FAKE	|1|
+
 
 ## Cyberbullying Classifier (sexism and Racism calssifier)
 
@@ -546,9 +549,9 @@ nlu.load('en.classify.spam').predict('Please sign up for this FREE membership it
 ```
 
 {:.steelBlueCols}
-| sentence_embeddings | 	category_sentence | 	category_spam | 	category_ham | 	sentence | 	category | 	id| 
-|---------------------|-----------------------|-------------------|-----------------|------------|----------|------|
-|[0.008322705514729023, 0.009957313537597656, 0...]| 	0 | 	1.0	 | 5.211698E-11 | 	Please sign up for this FREE membership it cos... | 	spam	| 1 | 
+|sentence_embeddings|	category_confidence| 	sentence| 	category | 	id | 
+|-------------------|----------------------|------------|-----------|-------|
+|[0.008322705514729023, 0.009957313537597656, 0...]	| 1.000000	| Please sign up for this FREE membership it cos...	|spam	|1 | 
 
 ## Sarcasm Classifier
 
@@ -558,11 +561,10 @@ nlu.load('en.classify.sarcasm').predict('gotta love the teachers who give examns
 
 
 {:.steelBlueCols}
-
-| sentence_embeddings | 	category_sentence  | 	category_normal	| category_sarcasm |  	sentence | 	category | 	id | 
-|---------------------|------------------------|--------------------|------------------|-------------|-----------|-----|
-| [-0.03146284446120262, 0.04071342945098877, 0....	] | 0 | 	1.5087321E-5 | 	0.99998486	| gotta love the teachers who give examns on the...	| sarcasm | 	1 |  
-
+| sentence_embeddings | 	category_confidence  | 	sentence | 	category  | 	id| 
+|---------------------|--------------------------|-----------|-----------|---------|
+|[-0.03146284446120262, 0.04071342945098877, 0....] | 0.999985	| gotta love the teachers who give examns on the...	| sarcasm	| 1 | 
+ 
 
 ## IMDB Movie Sentiment
 ```python

--- a/docs/en/predict_api.md
+++ b/docs/en/predict_api.md
@@ -9,6 +9,18 @@ modify_date: "2019-05-16"
 # Predict method Parameters 
 
 
+## Output metadata
+The NLU predict method has a boolean metdata parameter.     
+When it is set to True, NLU will output the confidence and additional metadata for each prediction.
+Its default value is False.
+
+```python
+nlu.load('lang').predict('What a wonderful day!')
+```
+
+
+
+
 ## Output Level parameter
 NLU defines 4 output levels for the generated predictions.     
 The output levels define how granular the predictions and outputs of NLU will be.     

--- a/docs/en/release_notes.md
+++ b/docs/en/release_notes.md
@@ -7,9 +7,34 @@ modify_date: "2020-06-12"
 ---
 
 NLU release notes 
-### 2.5.5.rc1
 
-The birth of a new Machine Learning library
+### 2.5.5
+- Confidence extraction bugfix
+
+### 2.5.4
+- Fixed bug with bad conversion of datatypes
+
+
+### 2.5.3
+- metadata paraemter for predict function, prettier outputs
+- Datatype consistency added for predictions
+
+### 2.5.2
+- Modin depenency bugfix
+
+### 2.5.1
+- Modin Support
+
+### 2.5.0
+
+- Support for Modin with Ray and Dask Backends
+- Consisten input and outputs for predict() . If you input Spark Dataframe , you get Spark Dataframe Back. If you input Modin dataframe, you get Modin back. Analogus for predictions on Numpy and Pandas objects
+
+
+
+### 2.5.0.rc1
+
+The birth of a new Machine Learning library       
 NLU provides out of the box
 
 - 200+ pretrained models and pipelines for most NLU tasks ( Sentiment, Language Detection, NER, POS, Spellchecking)

--- a/docs/index.md
+++ b/docs/index.md
@@ -8,13 +8,13 @@ article_header:
   actions:
     - text: Getting Started
       type: error
-      url: /docs/en/quickstart    
+      url: /docs/en/install    
     - text: '<i class="fab fa-github"></i> GitHub'
       type: outline-theme-dark
-      url: https://github.com/johnsnowlabs/spark-nlp  
+      url: https://github.com/JohnSnowLabs/nlu  
     - text: '<i class="fab fa-slack-hash"></i> Slack' 
       type: outline-theme-dark
-      url: https://join.slack.com/t/spark-nlp/shared_invite/enQtNjA4MTE2MDI1MDkxLWVjNWUzOGNlODg1Y2FkNGEzNDQ1NDJjMjc3Y2FkOGFmN2Q3ODIyZGVhMzU0NGM3NzRjNDkyZjZlZTQ0YzY1N2I    
+      url: https://app.slack.com/client/T9BRVC9AT/C0196BQCDPY    
 
   height: 50vh
   theme: dark

--- a/nlu/__init__.py
+++ b/nlu/__init__.py
@@ -2,6 +2,8 @@ import nlu
 import logging
 from nlu.namespace import NameSpace
 from sys import exit
+import warnings
+warnings.filterwarnings("ignore")
 
 logger = logging.getLogger('nlu')
 # logger.setLevel(logging.INFO)
@@ -518,5 +520,5 @@ def print_all_nlu_components():
 class NLU_error():
     def __init__(self):
         pass
-    def predict(self, text, output_level='error', output_positions='error'):
+    def predict(self, text, output_level='error', positions='error', metadata='error'):
         print('The NLU components could not be properly created. Please check previous print and Verbose mode for further info')

--- a/nlu/pipeline.py
+++ b/nlu/pipeline.py
@@ -238,7 +238,7 @@ class NLUPipeline(BasePipe):
                         # sadly because the Spark SQL method 'greatest()' does not work properly on scientific notation, we must cast our metadata to decimal with limited precision
                         # scientific notation starts after 6 decimal places, so we can have at most exactly 6
                         # since greatest() breaks the dataframe Schema, we must rename the columns first or run into issues with Pysark Struct queriying
-                        for key in cols_to_max : ptmp = ptmp.withColumn(key.replace('.','_'), pyspark_col(key).cast('decimal(6,6)'))
+                        for key in cols_to_max : ptmp = ptmp.withColumn(key.replace('.','_'), pyspark_col(key).cast('decimal(7,6)'))
                         # casted = ptmp.select(*(pyspark_col(c).cast("decimal(6,6)").alias(c.replace('.','_')) for c in cols_to_max))
                         
                         max_confidence_name  = field.split('.')[0] +'_confidence'

--- a/nlu/pipeline.py
+++ b/nlu/pipeline.py
@@ -9,11 +9,10 @@ import nlu
 logger = logging.getLogger('nlu')
 
 
-from pyspark.sql.functions import flatten, explode, arrays_zip, map_keys, map_values, monotonically_increasing_id
+from pyspark.sql.functions import flatten, explode, arrays_zip, map_keys, map_values, monotonically_increasing_id, greatest
 from pyspark.sql.functions import col as pyspark_col
 from pyspark.sql.functions import udf
 from pyspark.sql.types import ArrayType,FloatType, StringType, DoubleType
-import modin.pandas as mpd
 
 
 class BasePipe():
@@ -176,8 +175,8 @@ class NLUPipeline(BasePipe):
         return field_types_dict
 
 
-    def rename_columns_and_extract_map_values(self,ptmp, fields_to_rename, same_output_level, stranger_features=[]):
-        # This method takes in a Spark dataframe that is the result of an explosion or not lol.
+    def rename_columns_and_extract_map_values(self,ptmp, fields_to_rename, same_output_level, stranger_features=[], meta=True):
+        # This method takes in a Spark dataframe that is the result of an explosion or not after the spark Pipeline transformation .
         # It will peform the following transformations on the dataframe:
         # 1. Rename the exploded columns to something more meaningful
         # 2. Extract Meta data values of columns that contain maps if the data is relevant
@@ -185,6 +184,7 @@ class NLUPipeline(BasePipe):
         # @ param ptmp The dataframe which contains the columns wto be renamed
         # @ param fields_to_nreame : A list of field names that will be renamed in the dataframe.
         # @ param same_output_level : Wether the fields that are going to be renamed are at the same output level as the pipe or at a different one.
+        # @ param meta: wether  to get meta data like prediction confidence or not
         # @ return : Returns tuple (list, SparkDataFrame), where the first element is a list with all the new names and the second element is a new Spark Dataframe which contains all the renamed and also old columns
 
         columns_for_select = []
@@ -216,26 +216,28 @@ class NLUPipeline(BasePipe):
                     new_fields = []
                     # we iterate over the keys in the metadata and use them as new column names. The values will become the values in the columns.
                     keys_in_metadata = list(ptmp.select(field).take(1)[0].asDict()['metadata'][0].keys()) # 
-
-                    for key in keys_in_metadata:
-                        #drop sentences keys from Lang detector, they seem irrelevant.
-                        if key == 'sentence' and 'language' in field  : continue 
-                        new_fields.append(new_field.replace('metadata',key))
-
-                        # all the metadata is in a list together with then non meta data features. We must select them via res.i
-                        # ptmp = ptmp.withColumn(new_fields[-1],map_values('res.' + str(fields_to_rename.index(field)) + '.'+key) )
+                    
+                    if meta == True :  # get all meta data 
+                        for key in keys_in_metadata:
+                            #drop sentences keys from Lang detector, they seem irrelevant.
+                            if key == 'sentence' and 'language' in field  : continue 
+                            new_fields.append(new_field.replace('metadata',key))
+    
+                            
+                            ptmp = ptmp.withColumn(new_fields[-1],pyspark_col(('res.' + str(fields_to_rename.index(field)) + '.'+key) ))
+    
+                            columns_for_select.append(new_fields[-1])   
+    
+    
+                            logger.info('Created Meta Data for : nr=%s , original Meta Data key name=%s and new  new_name=%s ', i, key,new_fields[-1])
+                    else :  # Get only meta data with greatest value (highest prob)
+                        cols_to_max = []
+                        for key in keys_in_metadata: cols_to_max.append('res.' + str(fields_to_rename.index(field)) + '.'+key)
                         
-                        # Normal case or make this specialf for language
-                        # ptmp = ptmp.withColumnRenamed('res.' + str(fields_to_rename.index(field)) + '.'+key ,new_fields[-1])                        
-                        # ptmp = ptmp.withColumn(new_fields[-1],lit('res.' + str(fields_to_rename.index(field)) + '.'+key) )
-                        # ptmp[new_fields[-1]] = ptmp.select('res.' + str(fields_to_rename.index(field)) + '.'+key)
-                        ptmp = ptmp.withColumn(new_fields[-1],pyspark_col(('res.' + str(fields_to_rename.index(field)) + '.'+key) ))
-
-                        columns_for_select.append(new_fields[-1])   
-
-
-                        logger.info('Created Meta Data for : nr=%s , original Meta Data key name=%s and new  new_name=%s ', i, key,new_fields[-1])
-
+                        max_confidence_name  = field.split('.')[0] +'_confidence'
+                        ptmp = ptmp.withColumn(max_confidence_name , greatest(*cols_to_max))
+                        columns_for_select.append(max_confidence_name)
+                        
                     continue
 
 
@@ -249,13 +251,16 @@ class NLUPipeline(BasePipe):
             for i, field in enumerate(reorderd_fields_to_rename):
                 if self.raw_text_column in field: continue
                 new_field = field.replace('.', '_').replace('_result','').replace('_embeddings_embeddings','_embeddings')
-                if 'metadata' in field :  
+                if 'metadata' in field :
+
                     logger.info('Getting Meta Data for   : nr=%s , name=%s with new_name=%s and original', i, field,new_field)
                     # we iterate over the keys in the metadata and use them as new column names. The values will become the values in the columns.
                     keys_in_metadata = list(ptmp.select(field).take(1)[0].asDict()['metadata'][0].keys()) # 
                     if 'sentence' in keys_in_metadata : keys_in_metadata.remove('sentence')
+                    
                     new_fields=[]
                     for key in keys_in_metadata: 
+                        # we cant skip getting  key values for everything, even if meta=false. This is because we need to get the greatest of all confidence values , for this we must unpack them first..
                         new_fields.append(new_field.replace('metadata',key))
 
                         # These Pyspark UDF extracts from a list of maps all the map values for positive and negative confidence and also spell costs
@@ -263,11 +268,19 @@ class NLUPipeline(BasePipe):
 
                         #extract map values for list of maps 
                         array_map_values = udf(lambda z: extract_map_values(z), ArrayType(FloatType()))
-                        ptmp = ptmp.withColumn(new_fields[-1],array_map_values(field)) 
-                        columns_for_select += new_fields
-                        logger.info('Created Meta Data for   : nr=%s , name=%s with new_name=%s and original', i, field,new_fields[-1])
-                    continue
 
+                        ptmp = ptmp.withColumn(new_fields[-1],array_map_values(field)) 
+                        
+                        columns_for_select += new_fields # todo somwhow seems wierd to add here 
+                        logger.info('Created Meta Data for   : nr=%s , name=%s with new_name=%s and original', i, field,new_fields[-1])
+
+                    if meta == True : continue 
+                    else : # We gotta get the max confidence column, remove all other cols for selection
+                        ptmp = ptmp.withColumn('prediction_confidence',array_map_values(*new_fields))
+                        columns_for_select -= new_fields  
+                        columns_for_select.append('prediction_confidence') 
+                    continue # end of special meta data case 
+                
 
                 ptmp = ptmp.withColumn(new_field, ptmp[field])  # get the outputlevel results row by row
                 logger.info('Renaming non exploded field  : nr=%s , name=%s to new_name=%s', i, field,new_field)
@@ -303,7 +316,7 @@ class NLUPipeline(BasePipe):
 
 
 
-    def pythonify_spark_dataframe(self, processed, get_different_level_output=True, keep_stranger_features = True, stranger_features = [] , drop_irrelevant_cols=True):
+    def pythonify_spark_dataframe(self, processed, get_different_level_output=True, keep_stranger_features = True, stranger_features = [] , drop_irrelevant_cols=True, output_metadata=False):
         '''
         This functions takes in a spark dataframe with Spark NLP annotations in it and transforms it into a Pandas Dataframe with common feature types for further NLP/NLU downstream tasks.
             It does this by performing the following consecutive steps :
@@ -318,6 +331,7 @@ class NLUPipeline(BasePipe):
         :param stranger_features: A list of features which are not known to NLU and inside of the input DF. 
                                     Basically all columns, which are not named 'text' in the input. 
                                     If keep_stranger_features== True, then these features will be exploded, if output_level == DOCUMENt, otherwise they will not be exploded
+        :param output_metadata: Wether to keep or drop additional metadataf or predictions, like prediction confidence  
         :return: Pandas dataframe which easy accessable features
         '''
         
@@ -383,9 +397,10 @@ class NLUPipeline(BasePipe):
         logger.info(' zipping and exploding columnns %s-', same_output_level_fields)
 
         # explode the columns which are at the same output level..if there are maps at the different output level we will get array maps.  then we use some UDF functions to extract the resulting array maps 
-        ptmp,final_select_same_output_level =  self.rename_columns_and_extract_map_values(ptmp=ptmp, fields_to_rename=same_output_level_fields, same_output_level=True, stranger_features=stranger_features)
+      
+        ptmp,final_select_same_output_level =  self.rename_columns_and_extract_map_values(ptmp=ptmp, fields_to_rename=same_output_level_fields, same_output_level=True, stranger_features=stranger_features, meta=output_metadata)
         if get_different_level_output :
-            ptmp,final_select_not_at_same_output_level = self.rename_columns_and_extract_map_values(ptmp=ptmp, fields_to_rename=not_at_same_output_level_fields, same_output_level=False)
+            ptmp,final_select_not_at_same_output_level = self.rename_columns_and_extract_map_values(ptmp=ptmp, fields_to_rename=not_at_same_output_level_fields, same_output_level=False, meta=output_metadata)
 
 
         if self.output_level != 'document':final_select_not_at_same_output_level+= stranger_features
@@ -416,11 +431,13 @@ class NLUPipeline(BasePipe):
         elif self.output_datatype == 'pandas' : 
             return sdf.toPandas()
         elif self.output_datatype == 'modin' :
+            import modin.pandas as mpd
             return mpd.DataFrame(sdf.toPandas())
         # todo actual series and return String/array objects
         elif self.output_datatype == 'pandas_series' :
             return sdf.toPandas()
         elif self.output_datatype == 'modin_series' :
+            import modin.pandas as mpd
             return mpd.DataFrame(sdf.toPandas())
         elif self.output_datatype == 'numpy' :
             return sdf.toPandas().to_numpy()
@@ -458,18 +475,19 @@ class NLUPipeline(BasePipe):
 
         return cols
 
-    def predict(self, data, output_level='', output_positions=False, keep_stranger_features=True):
+    def predict(self, data, output_level='', positions=False, keep_stranger_features=True, metadata=False):
         '''
         Annotates a Pandas Dataframe/Pandas Series/Numpy Array/Spark DataFrame/Python List strings /Python String
         
         :param data: 
         :param output_level: 
-        :param output_positions: 
+        :param positions: 
         :param keep_stranger_features: 
+        :param metadata:weather to keep additonal metadata in final df or not 
         :return: 
         '''
         if output_level !='': self.output_level = output_level
-        self.output_positions= output_positions
+        self.output_positions= positions
         if not self.is_fitted: self.fit()
         sdf = None
         import pyspark  
@@ -484,12 +502,8 @@ class NLUPipeline(BasePipe):
                     sdf = self.spark_transformer_pipe.transform(data )
                 else :
                     print('Could not find column named "text" in input Pandas Dataframe. Please ensure one column named such exists. Columns in DF are : ', data.columns)
-            if type(data) is pd.DataFrame or type(data) is mpd.DataFrame :  # casting follows pd->spark->pd
+            if type(data) is pd.DataFrame:  # casting follows pd->spark->pd
                 self.output_datatype = 'pandas'
- 
-                if type(data) is mpd.DataFrame  : 
-                    data = pd.DataFrame(data.to_dict()) # create pandas to support type inference
-                    self.output_datatype = 'modin'
                 
                 if self.raw_text_column in data.columns:
                     if len(data.columns) > 1 :
@@ -501,12 +515,8 @@ class NLUPipeline(BasePipe):
                     self.spark.createDataFrame(data ))
                 else : 
                     print('Could not find column named "text" in input Pandas Dataframe. Please ensure one column named such exists. Columns in DF are : ', data.columns)
-            elif type(data) is pd.Series or type(data) is mpd.Series:  # for df['text'] colum/series passing casting follows pseries->pdf->spark->pd
+            elif type(data) is pd.Series:  # for df['text'] colum/series passing casting follows pseries->pdf->spark->pd
                 self.output_datatype='pandas_series'
-                if type(data) is mpd.Series  :
-                    self.output_datatype='modin_series'
-                    data = pd.Series(data.to_dict()) # create pandas to support type inference
-
                 data = pd.DataFrame(data).dropna(axis=1, how='all')
                 
                 if self.raw_text_column in data.columns: sdf = \
@@ -537,10 +547,40 @@ class NLUPipeline(BasePipe):
             elif type(data) is dict():  # Assumes values should be predicted
                 print('Predicting on dictionaries currently not supported. Please input either a Pandas Dataframe with a string column named "text"  or a String or a list of strings. ' )
                 return ''
-            
-            
-            # TODO pass the datatype we got to the pythonify  method, so we can returnt he same datatype to the user
-            return self.pythonify_spark_dataframe(sdf, self.output_different_levels, keep_stranger_features=keep_stranger_features, stranger_features=stranger_features)
+            else : # Modin tests, This could crash if Modin not installed 
+                try : 
+                    import modin.pandas as mpd
+                    if type(data) is mpd.DataFrame  :
+                        data = pd.DataFrame(data.to_dict()) # create pandas to support type inference
+                        self.output_datatype = 'modin'
+    
+                    if self.raw_text_column in data.columns:
+                        if len(data.columns) > 1 :
+                            data = data.where(pd.notnull(data), None) # make  Nans to None, or spark will crash
+                            data = data.dropna(axis=1, how='all')
+                            stranger_features = list( set(data.columns) - set(self.raw_text_column))
+                        sdf = self.spark_transformer_pipe.transform(
+                            # self.spark.createDataFrame(data[['text']]), ) # this takes text column as series and makes it DF
+                            self.spark.createDataFrame(data ))
+                    else :
+                        print('Could not find column named "text" in input Pandas Dataframe. Please ensure one column named such exists. Columns in DF are : ', data.columns)
+
+                    if type(data) is mpd.Series  :
+                        self.output_datatype='modin_series'
+                        data = pd.Series(data.to_dict()) # create pandas to support type inference
+                        data = pd.DataFrame(data).dropna(axis=1, how='all')
+        
+                        if self.raw_text_column in data.columns: sdf = \
+                            self.spark_transformer_pipe.transform(
+                                self.spark.createDataFrame(data[['text']]), )
+                        else: print('Could not find column named "text" in  Pandas Dataframe generated from input  Pandas Series. Please ensure one column named such exists. Columns in DF are : ', data.columns)
+                        
+                    
+                except : 
+                    print("If you use Modin, make sure you have installed 'pip install modin[ray]' or 'pip install modin[dask]' backend for Modin ")
+
+
+            return self.pythonify_spark_dataframe(sdf, self.output_different_levels, keep_stranger_features=keep_stranger_features, stranger_features=stranger_features, output_metadata=metadata)
         except : 
             import sys
             e = sys.exc_info()


### PR DESCRIPTION
In this pull the following release updates are  included in addition to various documentation updates 

NLU release notes 

### 2.5.5
- Confidence extraction bugfix

### 2.5.4
- Fixed bug with bad conversion of datatypes


### 2.5.3
- metadata paraemter for predict function, prettier outputs
- Datatype consistency added for predictions

### 2.5.2
- Modin depenency bugfix

### 2.5.1
- Modin Support

### 2.5.0

- Support for Modin with Ray and Dask Backends
- Consisten input and outputs for predict() . If you input Spark Dataframe , you get Spark Dataframe Back. If you input Modin dataframe, you get Modin back. Analogus for predictions on Numpy and Pandas objects



