### PR TITLE
Fix page content width

### DIFF
--- a/docs/_sass/layout/_page.scss
+++ b/docs/_sass/layout/_page.scss
@@ -43,7 +43,7 @@ html,
 .page__content {
   @include flex(1);
   width: 100%;
-  margin: 0 auto;
+  margin-left: $sidebar-width;
   @media print {
     padding-bottom: 0;
   }


### PR DESCRIPTION
Previously, the page content was covered by the leftbar.

before:
![Screen Shot 2020-09-25 at 18 59 25](https://user-images.githubusercontent.com/31281983/94322740-4acbc400-ff61-11ea-8ae1-0e53890fd479.png)

after:
![Screen Shot 2020-09-25 at 18 59 13](https://user-images.githubusercontent.com/31281983/94322745-4dc6b480-ff61-11ea-8767-764858cfc9cf.png)

