### PR TITLE
Relax the pyspark/spark-nlp dependencies

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ with open(path.join(here, 'README.md'), encoding='utf-8') as f:
     long_description = f.read()
 
 REQUIRED_PKGS = [
-    'pyspark>=2.4.4,<2.5',
+    'pyspark>=2.4.0,<2.5',
     'spark-nlp>=2.6.2,<2.7',
     'numpy',
     'pyarrow>=0.16.0',

--- a/setup.py
+++ b/setup.py
@@ -18,8 +18,8 @@ with open(path.join(here, 'README.md'), encoding='utf-8') as f:
     long_description = f.read()
 
 REQUIRED_PKGS = [
-    'pyspark==2.4.4',
-    'spark-nlp==2.6.2',
+    'pyspark>=2.4.4,<2.5',
+    'spark-nlp>=2.6.2,<2.7',
     'numpy',
     'pyarrow>=0.16.0',
     'pandas',


### PR DESCRIPTION
Currently, NLU depends on the exact versions of pyspark & spark-nlp.  This limits its
usage with newer PySpark & Spark-NLP versions.  This commit relax these dependencies,
allowing to use compatible versions of the packages (tested with Spark-NLP 2.6.2)