### PR TITLE
 Intent and Action Classification,  analyze Chinese News and the Crypto market, train a classifier that understands 100+ languages, translate between 200 + languages, answer questions, summarize text, and much more in NLU 1.1.3

### DIFF
--- a/docs/_data/navigation.yml
+++ b/docs/_data/navigation.yml
@@ -15,7 +15,7 @@ header:
   - title: '<span style="color: #FF8A00;"><i class="fab fa-github fa-2x"></i></span>'
     url: https://github.com/JohnSnowLabs/nlu
   - title: '<span style="color: #FF8A00;"><i class="fab fa-slack-hash fa-2x"></i></span>'
-    url: https://join.slack.com/t/spark-nlp/shared_invite/enQtNjA4MTE2MDI1MDkxLWVjNWUzOGNlODg1Y2FkNGEzNDQ1NDJjMjc3Y2FkOGFmN2Q3ODIyZGVhMzU0NGM3NzRjNDkyZjZlZTQ0YzY1N2I
+    url: https://join.slack.com/t/spark-nlp/shared_invite/zt-lutct9gm-kuUazcyFKhuGY3_0AMkxqA
 docs-en:
   - title:     Getting Started
     children:

--- a/docs/backup.md
+++ b/docs/backup.md
@@ -14,7 +14,7 @@ article_header:
       url: https://github.com/johnsnowlabs/spark-nlp  
     - text: '<i class="fab fa-slack-hash"></i> Slack' 
       type: outline-theme-dark
-      url: https://join.slack.com/t/spark-nlp/shared_invite/enQtNjA4MTE2MDI1MDkxLWVjNWUzOGNlODg1Y2FkNGEzNDQ1NDJjMjc3Y2FkOGFmN2Q3ODIyZGVhMzU0NGM3NzRjNDkyZjZlZTQ0YzY1N2I    
+      url: https://join.slack.com/t/spark-nlp/shared_invite/zt-lutct9gm-kuUazcyFKhuGY3_0AMkxqA    
 
   height: 50vh
   theme: dark

--- a/docs/en/load_api.md
+++ b/docs/en/load_api.md
@@ -53,12 +53,11 @@ To configure your model or pipeline, first load a NLU component and use the prin
 The print outputs tell you at which index of the pipe_components attribute which NLU component is located.   
 Via  setters which are named according to the parameter values a model can be configured
 
-
 ```python
-#example for configuring the first element in the pipe
+# example for configuring the first element in the pipe
 pipe = nlu.load('en.sentiment.twitter')
 pipe.generate_class_metadata_table()
-document_assembler_model = pipe.pipe_components[0].model
+document_assembler_model = pipe.components[0].model
 document_assembler_model.setCleanupMode('inplace')
 ```
 

--- a/docs/en/release_notes.md
+++ b/docs/en/release_notes.md
@@ -13,6 +13,25 @@ modify_date: "2020-06-12"
 
 <div class="h3-box" markdown="1">
 
+## NLU 1.1.3 Release Notes
+
+
+### New NLU Webinar
+
+### NLU 1.1.3 Enhancements
+- Added automatic conversion  to Sentence Embeddings of Word Embeddings when there is no Sentence Embedding Avaiable and a model needs the converted version to run.
+
+
+
+### NLU 1.1.3 Bug Fixes
+- Fixed a bug that caused `ur.sentiment` NLU pipeline to build incorrectly
+- Fixed a bug that caused `sentiment.imdb.glove` NLU pipeline to build incorrectly
+- Fixed a bug that caused `en.sentiment.glove.imdb` NLU pipeline to build incorrectly
+
+
+
+### New  Easy NLU 1-liners in 1.1.2
+
 ## NLU 1.1.2 Release Notes
 
 We are very happy to announce NLU 1.1.2 has been released with the integration of 30+ models and pipelines Bengali Named Entity Recognition, Hindi Word Embeddings,

--- a/docs/en/release_notes.md
+++ b/docs/en/release_notes.md
@@ -13,24 +13,179 @@ modify_date: "2020-06-12"
 
 <div class="h3-box" markdown="1">
 
+# Intent and Action Classification,  analyze Chinese News and the Crypto market, train a classifier that understands 100+ languages, translate between 200 + languages, answer questions, summarize text, and much more in NLU 1.1.3
+
 ## NLU 1.1.3 Release Notes
+We are very excited to announce that the latest NLU release comes with a new pretrained Intent Classifier and NER Action Extractor for text related to
+music, restaurants, and movies trained on the SNIPS dataset. Make sure to check out the models hub and the easy 1-liners for more info!
+
+In addition to that, new NER and Embedding models for Bengali are now available
+
+Finally, there is a new NLU Webinar with 9 accompanying tutorial notebooks which teach you  a lot of things and is segmented into the following parts :
+
+- Part1: Easy 1 Liners
+  - Spell checking/Sentiment/POS/NER/ BERTtology embeddings
+- Part2: Data analysis and NLP tasks on [Crypto News Headline dataset](https://www.kaggle.com/kashnitsky/news-about-major-cryptocurrencies-20132018-40k)
+  - Preprocessing and extracting Emotions, Keywords, Named Entities and visualize them
+- Part3: NLU Multi-Lingual 1 Liners with [Microsoft's Marian Models](https://marian-nmt.github.io/publications/)
+  - Translate between 200+ languages (and classify lang afterward)
+- Part 4: Data analysis and NLP tasks on [Chinese News Article Dataset](https://github.com/JohnSnowLabs/nlu/blob/master/examples/webinars_conferences_etc/multi_lingual_webinar/4_Unsupervise_Chinese_Keyword_Extraction_NER_and_Translation_from_Chinese_News.ipynb)
+  - Word Segmentation, Lemmatization, Extract Keywords, Named Entities and translate to english
+- Part 5: Train a sentiment Classifier that understands 100+ Languages
+  - Train on a french sentiment dataset and predict the sentiment of 100+ languages with [language-agnostic BERT Sentence Embedding](https://arxiv.org/abs/2007.01852)
+- Part 6: Question answering, Summarization, Squad and more with [Google's T5](https://arxiv.org/abs/1910.10683)
+  - T5 Question answering and 18 + other NLP tasks ([SQUAD](https://arxiv.org/abs/1606.05250) / [GLUE](https://arxiv.org/abs/1804.07461) / [SUPER GLUE](https://super.gluebenchmark.com/))
+
+
+### New Models
+
+#### NLU 1.1.3 New Non-English Models
+
+| Language | nlu.load() reference                                         | Spark NLP Model reference                                    | Type                  |
+| -------- | ------------------------------------------------------------ | ------------------------------------------------------------ | --------------------- |
+| Bengali  | [bn.ner.cc_300d](https://nlp.johnsnowlabs.com/2021/02/10/bengali_cc_300d_bn.html) | [ bengaliner_cc_300d](https://nlp.johnsnowlabs.com/2021/02/10/bengali_cc_300d_bn.html) | NerDLModel    |
+| Bengali  | [bn.embed](https://nlp.johnsnowlabs.com/2021/02/10/bengaliner_cc_300d_bn.html) | [bengali_cc_300d](https://nlp.johnsnowlabs.com/2021/02/10/bengaliner_cc_300d_bn.html) | NerDLModel            |
+| Bengali  | [bn.embed.cc_300d](https://nlp.johnsnowlabs.com/2021/02/10/bengaliner_cc_300d_bn.html) | [bengali_cc_300d](https://nlp.johnsnowlabs.com/2021/02/10/bengaliner_cc_300d_bn.html) | Word Embeddings Model (Alias)    |
+| Bengali  | [bn.embed.glove](https://nlp.johnsnowlabs.com/2021/02/10/bengaliner_cc_300d_bn.html) | [bengali_cc_300d](https://nlp.johnsnowlabs.com/2021/02/10/bengaliner_cc_300d_bn.html) |  Word Embeddings Model (Alias)|
+
+
+
+
+
+#### NLU 1.1.3 New English Models
+
+|Language | nlu.load() reference | Spark NLP Model reference | Type |
+|---------|---------------------|----------------------------|------|
+| English | [en.classify.snips](https://nlp.johnsnowlabs.com/2021/02/15/nerdl_snips_100d_en.html) |[nerdl_snips_100d](https://nlp.johnsnowlabs.com/2021/02/15/nerdl_snips_100d_en.html)     | NerDLModel |
+| English | [en.ner.snips](https://nlp.johnsnowlabs.com/2021/02/15/classifierdl_use_snips_en.html) |[classifierdl_use_snips](https://nlp.johnsnowlabs.com/2021/02/15/classifierdl_use_snips_en.html)|ClassifierDLModel|
+
+
 
 
 ### New NLU Webinar
+#### [State-of-the-art Natural Language Processing for 200+ Languages with 1 Line of code](https://events.johnsnowlabs.com/state-of-the-art-natural-language-processing-for-200-languages-with-1-line-of-code)
+
+
+##### Talk Abstract
+Learn to harness the power of 1,000+ production-grade & scalable NLP models for 200+ languages - all available with just 1 line of Python code by leveraging the open-source NLU library, which is powered by the widely popular Spark NLP.
+
+John Snow Labs has delivered over 80 releases of Spark NLP to date, making it the most widely used NLP library in the enterprise and providing the AI community with state-of-the-art accuracy and scale for a variety of common NLP tasks. The most recent releases include pre-trained models for over 200 languages - including languages that do not use spaces for word segmentation algorithms like Chinese, Japanese, and Korean, and languages written from right to left like Arabic, Farsi, Urdu, and Hebrew. All software and models are free and open source under an Apache 2.0 license.
+
+This webinar will show you how to leverage the multi-lingual capabilities of Spark NLP & NLU - including automated language detection for up to 375 languages, and the ability to perform translation, named entity recognition, stopword removal, lemmatization, and more in a variety of language families. We will create Python code in real-time and solve these problems in just 30 minutes. The notebooks will then be made freely available online.
+
+You can watch the [video here,](https://events.johnsnowlabs.com/state-of-the-art-natural-language-processing-for-200-languages-with-1-line-of-code)
+
+### NLU 1.1.3 New Notebooks and tutorials
+
+
+#### New Webinar Notebooks
+
+1. [NLU basics, easy 1-liners (Spellchecking, sentiment, NER, POS, BERT](https://github.com/JohnSnowLabs/nlu/blob/master/examples/webinars_conferences_etc/multi_lingual_webinar/0_liners_intro.ipynb)
+2. [Analyze Crypto News dataset with Keyword extraction, NER, Emotional distribution, and stemming](https://github.com/JohnSnowLabs/nlu/blob/master/examples/webinars_conferences_etc/multi_lingual_webinar/1_NLU_base_features_on_dataset_with_YAKE_Lemma_Stemm_classifiers_NER_.ipynb)
+3. [Translate Crypto News dataset between 300 Languages with the Marian Model (German, French, Hebrew examples)](https://github.com/JohnSnowLabs/nlu/blob/master/examples/webinars_conferences_etc/multi_lingual_webinar/2_multilingual_translation_with_marian_intro.ipynb)
+4. [Translate Crypto News dataset between 300 Languages with the Marian Model (Hindi, Russian, Chinese examples)](https://github.com/JohnSnowLabs/nlu/blob/master/examples/webinars_conferences_etc/multi_lingual_webinar/3_more_multi_lingual_NLP_translation_Asian_languages_with_Marian.ipynb)
+5. [Analyze Chinese News Headlines with Chinese Word Segmentation, Lemmatization, NER, and Keyword extraction](https://github.com/JohnSnowLabs/nlu/blob/master/examples/webinars_conferences_etc/multi_lingual_webinar/4_Unsupervise_Chinese_Keyword_Extraction_NER_and_Translation_from_Chinese_News.ipynb)
+6. [Train a Sentiment Classifier that will understand 100+ languages on just a French Dataset with the powerful Language Agnostic Bert Embeddings](https://github.com/JohnSnowLabs/nlu/blob/master/examples/webinars_conferences_etc/multi_lingual_webinar/5_multi_lingual_sentiment_classifier_training_for_over_100_languages.ipynb)
+7. [Summarize text and Answer Questions with T5](https://github.com/JohnSnowLabs/nlu/blob/master/examples/webinars_conferences_etc/multi_lingual_webinar/6_T5_question_answering_and_Text_summarization.ipynb)
+8. [Solve any task in 1 line from SQUAD, GLUE and SUPER GLUE with T5](https://github.com/JohnSnowLabs/nlu/blob/master/examples/webinars_conferences_etc/multi_lingual_webinar/7_T5_SQUAD_GLUE_SUPER_GLUE_TASKS.ipynb)
+9. [Overview of models for various languages](https://github.com/JohnSnowLabs/nlu/blob/master/examples/webinars_conferences_etc/multi_lingual_webinar/8_Multi_lingual_ner_pos_stop_words_sentiment_pretrained.ipynb)
+
+
+
+
+
+#### New easy NLU 1-liners in NLU 1.1.3
+
+####  [Detect actions in general commands related to music, restaurant, movies.](https://nlp.johnsnowlabs.com/2021/02/15/nerdl_snips_100d_en.html)
+
+
+```python
+nlu.load("en.classify.snips").predict("book a spot for nona gray  myrtle and alison at a top-rated brasserie that is distant from wilson av on nov  the 4th  2030 that serves ouzeri",output_level = "document")
+```
+
+outputs :
+
+|                                               ner_confidence | entities                                                     | document                                                     | Entities_Classes                                             |
+| -----------------------------------------------------------: | :----------------------------------------------------------- | :----------------------------------------------------------- | :----------------------------------------------------------- |
+| [1.0, 1.0, 0.9997000098228455, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 0.9990000128746033, 1.0, 1.0, 1.0, 0.9965000152587891, 0.9998999834060669, 0.9567000269889832, 1.0, 1.0, 1.0, 0.9980000257492065, 0.9991999864578247, 0.9988999962806702, 1.0, 1.0, 0.9998999834060669] | ['nona gray myrtle and alison', 'top-rated', 'brasserie', 'distant', 'wilson av', 'nov the 4th 2030', 'ouzeri'] | book a spot for nona gray myrtle and alison at a top-rated brasserie that is distant from wilson av on nov the 4th 2030 that serves ouzeri | ['party_size_description', 'sort', 'restaurant_type', 'spatial_relation', 'poi', 'timeRange', 'cuisine'] |
+
+####  [Named Entity Recognition (NER) Model in Bengali (bengaliner_cc_300d)](https://nlp.johnsnowlabs.com/2021/02/10/bengaliner_cc_300d_bn.html)
+
+
+```python
+# Bengali for: 'Iajuddin Ahmed passed Matriculation from Munshiganj High School in 1947 and Intermediate from Munshiganj Horganga College in 1950.'
+nlu.load("bn.ner.cc_300d").predict("১৯৪৮ সালে ইয়াজউদ্দিন আহম্মেদ মুন্সিগঞ্জ উচ্চ বিদ্যালয় থেকে মেট্রিক পাশ করেন এবং ১৯৫০ সালে মুন্সিগঞ্জ হরগঙ্গা কলেজ থেকে ইন্টারমেডিয়েট পাশ করেন",output_level = "document")
+```
+
+outputs :
+
+| ner_confidence                                                                                                                                                                                                                                                                                                                                                                                                                       | entities                                                                           | Entities_Classes   | document                                                                                                                         |
+|---------------:|:-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|:-----------------------------------------------------------------------------------|:--------------------------------------|
+| [0.9987999796867371, 0.9854000210762024, 0.8604000210762024, 0.6686999797821045, 0.5289999842643738, 0.7009999752044678, 0.7684999704360962, 0.9979000091552734, 0.9976000189781189, 0.9930999875068665, 0.9994000196456909, 0.9879000186920166, 0.7407000064849854, 0.9215999841690063, 0.7657999992370605, 0.39419999718666077, 0.9124000072479248, 0.9932000041007996, 0.9919999837875366, 0.995199978351593, 0.9991999864578247] | ['সালে', 'ইয়াজউদ্দিন আহম্মেদ', 'মুন্সিগঞ্জ উচ্চ বিদ্যালয়', 'সালে', 'মুন্সিগঞ্জ হরগঙ্গা কলেজ'] | ['TIME', 'PER', 'ORG', 'TIME', 'ORG'] | ১৯৪৮ সালে ইয়াজউদ্দিন আহম্মেদ মুন্সিগঞ্জ উচ্চ বিদ্যালয় থেকে মেট্রিক পাশ করেন এবং ১৯৫০ সালে মুন্সিগঞ্জ হরগঙ্গা কলেজ থেকে ইন্টারমেডিয়েট পাশ করেন |
+
+#### [Identify intent in general text - SNIPS dataset](https://nlp.johnsnowlabs.com/2021/02/15/classifierdl_use_snips_en.html)
+
+
+```python
+nlu.load("en.ner.snips").predict("I want to bring six of us to a bistro in town that serves hot chicken sandwich that is within the same area",output_level = "document")
+```
+
+outputs :
+
+
+| document | snips | snips_confidence|
+|----------|------|------------------|
+| I want to bring six of us to a bistro in town that serves hot chicken sandwich that is within the same area | BookRestaurant |                  1 |
+
+
+#### [Word Embeddings for Bengali (bengali_cc_300d)](https://nlp.johnsnowlabs.com/2021/02/10/bengali_cc_300d_bn.html)
+
+
+
+
+```python
+# Bengali for : 'Iajuddin Ahmed passed Matriculation from Munshiganj High School in 1947 and Intermediate from Munshiganj Horganga College in 1950.'
+nlu.load("bn.embed").predict("১৯৪৮ সালে ইয়াজউদ্দিন আহম্মেদ মুন্সিগঞ্জ উচ্চ বিদ্যালয় থেকে মেট্রিক পাশ করেন এবং ১৯৫০ সালে মুন্সিগঞ্জ হরগঙ্গা কলেজ থেকে ইন্টারমেডিয়েট পাশ করেন",output_level = "document")
+```
+
+outputs :
+
+|                                                     document | bn_embed_embeddings                                          |
+| -----------------------------------------------------------: | :----------------------------------------------------------- |
+| ১৯৪৮ সালে ইয়াজউদ্দিন আহম্মেদ মুন্সিগঞ্জ উচ্চ বিদ্যালয় থেকে মেট্রিক পাশ করেন এবং ১৯৫০ সালে মুন্সিগঞ্জ হরগঙ্গা কলেজ থেকে ইন্টারমেডিয়েট পাশ করেন | [-0.0828      0.0683      0.0215     ...  0.0679     -0.0484...] |
+
+
 
 ### NLU 1.1.3 Enhancements
 - Added automatic conversion  to Sentence Embeddings of Word Embeddings when there is no Sentence Embedding Avaiable and a model needs the converted version to run.
-
 
 
 ### NLU 1.1.3 Bug Fixes
 - Fixed a bug that caused `ur.sentiment` NLU pipeline to build incorrectly
 - Fixed a bug that caused `sentiment.imdb.glove` NLU pipeline to build incorrectly
 - Fixed a bug that caused `en.sentiment.glove.imdb` NLU pipeline to build incorrectly
+- Fixed a bug that caused Spark 2.3.X environments to crash.
+
+### NLU Installation
+
+```bash
+# PyPi
+!pip install nlu pyspark==2.4.7
+#Conda
+# Install NLU from Anaconda/Conda
+conda install -c johnsnowlabs nlu
+```
+
+### Additional NLU ressources
+
+- [NLU Website](https://nlu.johnsnowlabs.com/)
+- [All NLU Tutorial Notebooks](https://nlu.johnsnowlabs.com/docs/en/notebooks)
+- [NLU Videos and Blogposts on NLU](https://nlp.johnsnowlabs.com/learn#pythons-nlu-library)
+- [NLU on Github](https://github.com/JohnSnowLabs/nlu)
+- [Suggestions or Questions? Contact us in Slack!](https://join.slack.com/t/spark-nlp/shared_invite/zt-lutct9gm-kuUazcyFKhuGY3_0AMkxqA)
 
 
 
-### New  Easy NLU 1-liners in 1.1.2
 
 ## NLU 1.1.2 Release Notes
 
@@ -730,7 +885,7 @@ Output:
 ```python
 
 # 'The people of Ohu know that the foundation of Bhojpuri was shaken' in Bengali
-nlu.load('bh.pos').predict("ओहु लोग के मालूम बा कि श्लील होखते भोजपुरी के नींव हिल जाई").to_markdown()
+nlu.load('bh.pos').predict("ओहु लोग के मालूम बा कि श्लील होखते भोजपुरी के नींव हिल जाई")
 ```
 
 Output:
@@ -755,7 +910,7 @@ Output:
 #### Amharic Part of Speech (POS)
 ```python
 # ' "Son, finish the job," he said.' in Amharic
-nlu.load('am.pos').predict('ልጅ ኡ ን ሥራ ው ን አስጨርስ ኧው ኣል ኧሁ ።"').to_markdown()
+nlu.load('am.pos').predict('ልጅ ኡ ን ሥራ ው ን አስጨርስ ኧው ኣል ኧሁ ።"')
 ```
 
 Output:
@@ -779,7 +934,7 @@ Output:
 #### Thai Sentiment Classification
 ```python
 #  'I love peanut butter and jelly!' in thai
-nlu.load('th.classify.sentiment').predict('ฉันชอบเนยถั่วและเยลลี่!')[['sentiment','sentiment_confidence']].to_markdown()
+nlu.load('th.classify.sentiment').predict('ฉันชอบเนยถั่วและเยลลี่!')[['sentiment','sentiment_confidence']]
 ```
 
 Output:
@@ -792,7 +947,7 @@ Output:
 #### Arabic Named Entity Recognition (NER)
 ```python
 # 'In 1918, the forces of the Arab Revolt liberated Damascus with the help of the British' in Arabic
-nlu.load('ar.ner').predict('في عام 1918 حررت قوات الثورة العربية دمشق بمساعدة من الإنكليز',output_level='chunk')[['entities_confidence','ner_confidence','entities']].to_markdown()
+nlu.load('ar.ner').predict('في عام 1918 حررت قوات الثورة العربية دمشق بمساعدة من الإنكليز',output_level='chunk')[['entities_confidence','ner_confidence','entities']]
 ```
 
 Output:

--- a/nlu/__init__.py
+++ b/nlu/__init__.py
@@ -160,7 +160,6 @@ discoverer = nlu.Discoverer()
 
 import os
 import sparknlp
-sparknlp.start()
 
 def read_nlu_info(path):
     f = open(os.path.join(path,'nlu_info.txt'), "r")

--- a/nlu/__init__.py
+++ b/nlu/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '1.1.1'
+__version__ = '1.1.3'
 
 import sys
 

--- a/nlu/__init__.py
+++ b/nlu/__init__.py
@@ -77,6 +77,7 @@ from nlu.components.utils.ner_to_chunk_converter.ner_to_chunk_converter import N
 from nlu.components.embedding import Embeddings
 from nlu.components.util import Util
 from nlu.components.utils.ner_to_chunk_converter import ner_to_chunk_converter
+from nlu.components.utils.sentence_embeddings.spark_nlp_sentence_embedding import SparkNLPSentenceEmbeddings
 
 # sentence
 from nlu.components.sentence_detectors.pragmatic_sentence_detector.sentence_detector import PragmaticSentenceDetector
@@ -295,7 +296,9 @@ def parse_language_from_nlu_ref(nlu_ref):
 
 def resolve_multi_lang_embed(language,sparknlp_reference):
     if language == 'ar' and 'glove' in sparknlp_reference : return 'arabic_w2v_cc_300d'
+    if language == 'ur' : return 'urduvec_140M_300d'
     else : return sparknlp_reference
+
 
 
 def get_default_component_of_type(missing_component_type,language='en'):
@@ -327,11 +330,11 @@ def get_default_component_of_type(missing_component_type,language='en'):
         if missing_component_type == 'ner_converter': return Util('ner_converter')
 
     else:
-        multi_lang =['ar']
+        multi_lang =['ar','ur']
         # if there is an @ in the name, we must get some specific pretrained model from the sparknlp reference that should follow after the @
         missing_component_type, sparknlp_reference = missing_component_type.split('@')
         if 'embed' in missing_component_type:
-            # TODO RESOLVE MULTI LANG EMBEDS
+
             if language in multi_lang : sparknlp_reference = resolve_multi_lang_embed(language,sparknlp_reference)
             return construct_component_from_identifier(language=language, component_type='embed',
                                                        nlp_ref=sparknlp_reference)

--- a/nlu/__init__.py
+++ b/nlu/__init__.py
@@ -227,7 +227,10 @@ def enable_verbose():
     ch.setLevel(logging.INFO)
     logger.addHandler(ch)
 
-
+def is_spark_23_installed():
+    version = pyspark.version.__version__
+    if '2.3' == version[:3]: return True
+    return False
 def load(request ='from_disk', path=None,verbose=False,version_checks=True):
     '''
     Load either a prebuild pipeline or a set of components identified by a whitespace seperated list of components
@@ -239,7 +242,8 @@ def load(request ='from_disk', path=None,verbose=False,version_checks=True):
     '''
     gc.collect()
     # if version_checks : check_pyspark_install()
-    spark = sparknlp.start()
+
+    spark = sparknlp.start(spark23=is_spark_23_installed())
     spark.catalog.clearCache()
     spark_started = True
     if verbose:

--- a/nlu/components/util.py
+++ b/nlu/components/util.py
@@ -1,4 +1,4 @@
-from nlu.pipe_components import SparkNLUComponent, NLUComponent
+from nlu.pipe_components import SparkNLUComponent
 
 class Util(SparkNLUComponent):
 
@@ -20,4 +20,7 @@ class Util(SparkNLUComponent):
             elif annotator_class == 'ner_to_chunk_converter' :
                 from nlu import NerToChunkConverter
                 self.model =  NerToChunkConverter.get_default_model()
+            elif annotator_class == 'sentence_embeddings':
+                from nlu import SparkNLPSentenceEmbeddings
+                self.model = SparkNLPSentenceEmbeddings.get_default_model()
         SparkNLUComponent.__init__(self, annotator_class, component_type)

--- a/nlu/components/utils/sentence_embeddings/component_infos.json
+++ b/nlu/components/utils/sentence_embeddings/component_infos.json
@@ -8,13 +8,13 @@
   ],
   "inputs": [
     "document",
-    "embeddings"
+    "word_embeddings"
   ],
   "type": "sentence_embeddings",
   "file_dependencies": {},
   "spark_input_column_names": [
     "document",
-    "embeddings"
+    "word_embeddings"
   ],
   "spark_output_column_names": [
     "sentence_embeddings"

--- a/nlu/components/utils/sentence_embeddings/spark_nlp_sentence_embedding.py
+++ b/nlu/components/utils/sentence_embeddings/spark_nlp_sentence_embedding.py
@@ -2,10 +2,10 @@ import nlu.pipe_components
 import sparknlp
 from sparknlp.annotator import *
 
-class SparkNLPSentenceEmbeddinge:
+class SparkNLPSentenceEmbeddings:
     @staticmethod
     def get_default_model():
         return  SentenceEmbeddings() \
-            .setInputCols(["document", "embeddings"]) \
+            .setInputCols(["document", "word_embeddings"]) \
             .setOutputCol("sentence_embeddings") \
             .setPoolingStrategy("AVERAGE")

--- a/nlu/namespace.py
+++ b/nlu/namespace.py
@@ -922,8 +922,7 @@ class NameSpace():
             'en.classify.cyberbullying': 'classifierdl_use_cyberbullying',  # Alias withouth embedding
             'en.classify.sarcasm': 'classifierdl_use_sarcasm',  # Alias withouth embedding
             'en.sentiment.twitter': 'sentimentdl_use_twitter',  # Alias withouth embedding
-            'en.sentiment.imdb': 'sentimentdl_glove_imdb',  # Default sentiment imdb with embeddigns glvoe
-        
+
             #2.6 Release models
             'en.yake' :'yake',
 
@@ -1453,6 +1452,7 @@ class NameSpace():
 
             'ur.sentiment' : 'sentimentdl_urduvec_imdb',
             'ur.embed' : 'urduvec_140M_300d' , # default ur embeds
+            'ur.embed.glove.300d' : 'urduvec_140M_300d' , # default ur embeds
             'ur.embed.urdu_vec_140M_300d' : 'urduvec_140M_300d' ,
             'ur.ner' : 'uner_mk_140M_300d' ,
             'ur.ner.mk_140M_300d' : 'uner_mk_140M_300d' ,

--- a/nlu/namespace.py
+++ b/nlu/namespace.py
@@ -241,7 +241,6 @@ class NameSpace():
 
 
         # 2.7.0 new aliases
-        't5': ('t5_base','model'),
         't5.summarize': ('t5_base','model'),
         't5.classify.grammar_correctness': ('t5_base','model'),
         't5.classify.sentiment': ('t5_base','model'),
@@ -1035,7 +1034,9 @@ class NameSpace():
             "en.ner.airline":"nerdl_atis_840b_300d",
             "en.ner.aspect.airline":"nerdl_atis_840b_300d",
             "en.ner.aspect.atis":"nerdl_atis_840b_300d",
-
+            # 2.7.3 snips
+            'en.classify.snips' : 'nerdl_snips_100d',
+            'en.ner.snips'      : 'classifierdl_use_snips'
 
 
         },
@@ -1178,6 +1179,10 @@ class NameSpace():
             "bn.pos": "pos_msri",
             'bn.ner':'ner_jifs_glove_840B_300d',
             'bn.ner.glove':'ner_jifs_glove_840B_300d',
+            'bn.embed.glove' : 'bengaliner_cc_300d',
+            'bn.embed' : 'bengaliner_cc_300d',
+            'bn.ner.cc':'bengali_cc_300d',
+            'bn.ner.cc_300d':'bengali_cc_300d',
 
     },
         'br': {

--- a/nlu/namespace.py
+++ b/nlu/namespace.py
@@ -1179,10 +1179,15 @@ class NameSpace():
             "bn.pos": "pos_msri",
             'bn.ner':'ner_jifs_glove_840B_300d',
             'bn.ner.glove':'ner_jifs_glove_840B_300d',
-            'bn.embed.glove' : 'bengaliner_cc_300d',
-            'bn.embed' : 'bengaliner_cc_300d',
-            'bn.ner.cc':'bengali_cc_300d',
-            'bn.ner.cc_300d':'bengali_cc_300d',
+
+            'bn.ner.cc_300d' : 'bengaliner_cc_300d',
+
+            'bn.embed.cc_300d':'bengali_cc_300d',
+
+
+            'bn.embed':'bengali_cc_300d',
+            'bn.embed.glove':'bengali_cc_300d',
+
 
     },
         'br': {

--- a/nlu/pipeline.py
+++ b/nlu/pipeline.py
@@ -1402,7 +1402,7 @@ class NLUPipeline(BasePipe):
             fname = os.path.split(exc_tb.tb_frame.f_code.co_filename)[1]
             print(exc_type, fname, exc_tb.tb_lineno)
             print(
-                'Stuck? Contact us on Slack! https://join.slack.com/t/spark-nlp/shared_invite/zt-j5ttxh0z-Fn3lQSG1Z0KpOs_SRxjdyw0196BQCDPY')
+                'Stuck? Contact us on Slack! https://join.slack.com/t/spark-nlp/shared_invite/zt-lutct9gm-kuUazcyFKhuGY3_0AMkxqA')
             if verbose :
                 err = sys.exc_info()[1]
                 print(str(err))

--- a/nlu/pipeline_logic.py
+++ b/nlu/pipeline_logic.py
@@ -106,7 +106,9 @@ class PipelineQueryVerifier():
                 if PipelineQueryVerifier.has_storage_ref(c) :
                     if PipelineQueryVerifier.extract_storage_ref(c) == storage_ref_to_find :
                         # Both components have Different Names AND their Storage Ref Matches up AND they both take in tokens -> Match
-                        if 'token' in component_to_check.component_info.inputs and c.component_info.type == 'word_embeddings' : return True
+                        if 'token' in component_to_check.component_info.inputs and c.component_info.type == 'word_embeddings' :
+                            logger.info(f'Match found = {c}')
+                            return True, None
 
                         # Since document and be substituted for sentence and vice versa if either of them matches up we have a match
                         if 'sentence_embeddings' in component_to_check.component_info.inputs and c.component_info.type == 'sentence_embeddings':
@@ -244,7 +246,6 @@ class PipelineQueryVerifier():
             The converter is a NLU Component Embelishement of the Spark NLP Sentence Embeddings Annotator
         """
         c = nlu.Util(annotator_class='sentence_embeddings')
-        print("GOT UTILLLLLLLLLLLLLLLLL", c)
         storage_ref = PipelineQueryVerifier.extract_storage_ref(component)
         c.model.setStorageRef(storage_ref)
         c.model.setInputCols('document','word_embeddings')

--- a/nlu/pipeline_logic.py
+++ b/nlu/pipeline_logic.py
@@ -36,11 +36,14 @@ class PipelineQueryVerifier():
         '''
 
 
+
         if type(component) == list or type(component) == set:
             for feature in component:
                 if 'embed' in feature: return True
             return False
         else:
+            if component.component_info.type =='word_embeddings' : return False
+            if component.component_info.type =='sentence_embeddings' : return False
             for feature in component.component_info.inputs:
                 if 'embed' in feature: return True
         return False
@@ -84,23 +87,41 @@ class PipelineQueryVerifier():
     @staticmethod
     def has_storage_ref(component):
         """Check if a storage ref is defined on the Spark NLP Annotator embelished by the NLU Component"""
-        for k,_ in component.extractParamMap().items():
+        print()
+        for k,_ in component.model.extractParamMap().items():
             if k.name =='storageRef' : return True
         return False
     @staticmethod
     def check_if_storage_ref_is_satisfied(component_to_check, pipe, storage_ref_to_find):
-        """Check if any other component in the pipeline has same storage ref as the input component"""
-
-        for c in pipe.pipe_components:
+        """Check if any other component in the pipeline has same storage ref as the input component..
+        Returns 1. If
+        If there is a candiate but it has different level, it will be returned as candidate
+        """
+        # If there is just 1 component, there is nothing to check
+        if len(pipe.components) == 1 : return False, None
+        conversion_candidate = None
+        logger.info(f'checking for storage={storage_ref_to_find} is avaiable in pipe..')
+        for c in pipe.components:
             if component_to_check.component_info.name != c.component_info.name:
                 if PipelineQueryVerifier.has_storage_ref(c) :
                     if PipelineQueryVerifier.extract_storage_ref(c) == storage_ref_to_find :
                         # Both components have Different Names AND their Storage Ref Matches up AND they both take in tokens -> Match
-                        if 'token' in c.component_info.inputs and 'token' in component_to_check.component_info.inputs: return True
+                        if 'token' in component_to_check.component_info.inputs and c.component_info.type == 'word_embeddings' : return True
+
+                        # Since document and be substituted for sentence and vice versa if either of them matches up we have a match
+                        if 'sentence_embeddings' in component_to_check.component_info.inputs and c.component_info.type == 'sentence_embeddings':
+                            logger.info(f'Match found = {c}')
+                            return True, None
+
                         # component_to_check requires Sentence_embedding but the Matching Storage_ref component takes in Token
-                        #   -> Convert the Output of the Match to SentenceLevel and feed the component_to_cheeck to the new component
-                        # 1. Figure out if component is Word/Sent/Chunk/Doc level
-                        return 'yay'
+                        #   -> Convert the Output of the Match to SentenceLevel and feed the component_to_check to the new component
+                        if 'sentence_embeddings' in component_to_check.component_info.inputs and c.component_info.type == 'word_embeddings':
+                            logger.info(f'Conversion Candidate found={c}')
+                            conversion_candidate = c
+
+
+        logger.info(f'No matching storage ref found')
+        return False, conversion_candidate
 
 
     @staticmethod
@@ -118,12 +139,12 @@ class PipelineQueryVerifier():
 
         '''
         logger.info('Resolving missing components')
-        pipe_requirements = [['sentence',
-                              'token']]  # default requirements so we can support all output levels. minimal extra comoputation effort. If we add CHUNK here, we will aalwayshave POS default
+        pipe_requirements = [['sentence','token']]  # default requirements so we can support all output levels. minimal extra comoputation effort. If we add CHUNK here, we will aalwayshave POS default
         pipe_provided_features = []
+        components_for_sentence_embedding_conversion = []
         pipe.has_trainable_components = False
         # pipe_types = [] # list of string identifiers
-        for component in pipe.pipe_components:
+        for component in pipe.components:
             trainable = PipelineQueryVerifier.is_untrained_model(component)
             if trainable : pipe.has_trainable_components = True
             # 1. Get all feature provisions from the pipeline
@@ -140,14 +161,17 @@ class PipelineQueryVerifier():
                     # there is no ref for Chunk embeddings, so we have a special case here and need to define a default value that will always be used for chunkers
                     storage_ref = 'glove'
                 else:
-                    # Todo storageRefResolution() here. StorageRef on Model must Match a storage Ref on a Embedding generator of same lang in the pipe!
+                    # We check if Storage ref is satisfied by some component and if it also is matched output_level_wise (checked by check_if_storage_ref_is_satisfied).
+                    # If there storage_ref is satisfied, we add a converter right away and update cols
                     storage_ref = PipelineQueryVerifier.extract_storage_ref(component)
 
-                    check_if_storage_ref_is_satisfied(component,pipe,storage_ref)
-                    check_if_storage_ref_satisfied_and_format_is_correct(component, pipe, storage_ref)
-                    # If there is a correct storage_ref, but it is of type word_emb and required is sent_emb then we add a converter
-                    checK_if_storage_ref_can_be_satisfied_by_conversion()
-                    # add_word_to_sent_conversion_and_update_component_inputs(embedding_to_convert, components_to_update)
+                    storage_ref_satisfied, conversion_candidate = PipelineQueryVerifier.check_if_storage_ref_is_satisfied(component, pipe, storage_ref)
+
+                    if not storage_ref_satisfied and conversion_candidate is not None :
+                        components_for_sentence_embedding_conversion.append(conversion_candidate)
+                        # pipe =  PipelineQueryVerifier.add_token_to_sentence_embedding_conversion_and_update_components(pipe, conversion_candidate,[])
+
+
 
                 inputs_with_sparknlp_reference = []
                 for feature in component.component_info.inputs:
@@ -180,11 +204,11 @@ class PipelineQueryVerifier():
 
         if len(missing_components) == 0:
             logger.info('No more components missing!')
-            return []
+            return [],[]
         else:
             # we must recaclulate the difference, because we reoved the spark nlp reference previously for our set operation. Since it was not 0, we ad the Spark NLP rererence back
             logger.info('Components missing=%s', str(missing_components))
-            return missing_components
+            return missing_components, components_for_sentence_embedding_conversion
 
     @staticmethod
     def add_ner_converter_if_required(pipe: NLUPipeline):
@@ -199,7 +223,7 @@ class PipelineQueryVerifier():
         ner_converter_exists = False
         ner_exists = False
 
-        for component in pipe.pipe_components:
+        for component in pipe.components:
             if 'ner' in component.component_info.outputs: ner_exists = True
             if 'entities' in component.component_info.outputs: ner_converter_exists = True
 
@@ -213,6 +237,25 @@ class PipelineQueryVerifier():
 
         return pipe
 
+
+    @staticmethod
+    def add_sentence_embedding_converter(component):
+        """ Return a Word to Sentence Embedding converter for a given Component. The input cols with match the Sentence Embedder ones.py
+            The converter is a NLU Component Embelishement of the Spark NLP Sentence Embeddings Annotator
+        """
+        c = nlu.Util(annotator_class='sentence_embeddings')
+        print("GOT UTILLLLLLLLLLLLLLLLL", c)
+        storage_ref = PipelineQueryVerifier.extract_storage_ref(component)
+        c.model.setStorageRef(storage_ref)
+        c.model.setInputCols('document','word_embeddings')
+        c.model.setOutputCol('sentence_embeddings@'+storage_ref)
+        c.component_info.spark_input_column_names = ['document','word_embeddings']
+        c.component_info.input_column_names = ['document','word_embeddings']
+
+        c.component_info.spark_output_column_names = ['sentence_embeddings@'+storage_ref]
+        c.component_info.output_column_names = ['sentence_embeddings@'+storage_ref]
+
+        return c
     @staticmethod
     def check_and_fix_nlu_pipeline(pipe: NLUPipeline):
         """Check if the NLU pipeline is ready to transform data and return it.
@@ -237,10 +280,20 @@ class PipelineQueryVerifier():
             # After new components have been added, we must loop again and check for the new components if requriements are met
 
             # Find missing components
-            missing_components = PipelineQueryVerifier.get_missing_required_features(pipe)
+            missing_components, components_for_sentence_embedding_conversion = PipelineQueryVerifier.get_missing_required_features(pipe)
+
+
             if len(missing_components) == 0: break  # Now all features are provided
 
+
+
             components_to_add = []
+
+            if len(components_for_sentence_embedding_conversion) > 0 :
+                for c in  components_for_sentence_embedding_conversion:
+                    converter = PipelineQueryVerifier.add_sentence_embedding_converter(c)
+                    if converter is not None : components_to_add.append(converter)
+
             # Create missing components
             for missing_component in missing_components:
                 if 'embedding' in missing_component or 'token' in missing_component: components_to_add.append(nlu.get_default_component_of_type(missing_component,language= pipe.lang))
@@ -288,10 +341,10 @@ class PipelineQueryVerifier():
         '''
 
 
-        for component_to_check in pipe.pipe_components:
+        for component_to_check in pipe.components:
             input_columns = set(component_to_check.component_info.spark_input_column_names)
             logger.info(f'Checking for component {component_to_check.component_info.name} wether inputs {input_columns} is satisfied by another component in the pipe ',)
-            for other_component in pipe.pipe_components:
+            for other_component in pipe.components:
                 if component_to_check.component_info.name == other_component.component_info.name: continue
                 output_columns = set(other_component.component_info.spark_output_column_names)
                 input_columns -= output_columns
@@ -301,7 +354,7 @@ class PipelineQueryVerifier():
             if len(input_columns) != 0 and not pipe.has_trainable_components:  # fix missing column name
                 logger.info(f"Fixing bad input col for C={component_to_check} untrainable pipe")
                 for missing_column in input_columns:
-                    for other_component in pipe.pipe_components:
+                    for other_component in pipe.components:
                         if component_to_check.component_info.name == other_component.component_info.name: continue
                         if other_component.component_info.type == missing_column:
                             # We update the output name for the component which provides our feature
@@ -315,7 +368,7 @@ class PipelineQueryVerifier():
 
                 # for trainable components, we change their input columns and leave other components outputs unchanged
                 for missing_column in input_columns:
-                    for other_component in pipe.pipe_components:
+                    for other_component in pipe.components:
                         if component_to_check.component_info.name == other_component.component_info.name: continue
                         if other_component.component_info.type == missing_column:
                             # We update the input col name for the componenet that has missing cols
@@ -351,12 +404,12 @@ class PipelineQueryVerifier():
 
         all_names_provided = False
 
-        for component_to_check in pipe.pipe_components:
+        for component_to_check in pipe.components:
             all_names_provided_for_component = False
             input_columns = set(component_to_check.component_info.spark_input_column_names)
             logger.info('Checking for component %s wether input %s is satisfied by another component in the pipe ',
                         component_to_check.component_info.name, input_columns)
-            for other_component in pipe.pipe_components:
+            for other_component in pipe.components:
                 if component_to_check.component_info.name == other_component.component_info.name: continue
                 output_columns = set(other_component.component_info.spark_output_column_names)
                 input_columns -= output_columns  # set substraction
@@ -365,7 +418,7 @@ class PipelineQueryVerifier():
 
             if len(input_columns) != 0:  # fix missing column name
                 for missing_column in input_columns:
-                    for other_component in pipe.pipe_components:
+                    for other_component in pipe.components:
                         if component_to_check.component_info.name == other_component.component_info.name: continue
                         if other_component.component_info.type == missing_column:
                             # resolve which setter to use ...
@@ -389,7 +442,7 @@ class PipelineQueryVerifier():
         logger.info("Starting to optimize component order ")
         correct_order_component_pipeline = []
         all_components_orderd = False
-        all_components = pipe.pipe_components
+        all_components = pipe.components
         provided_features = []
         while all_components_orderd == False:
             for component in all_components:
@@ -401,7 +454,7 @@ class PipelineQueryVerifier():
                     for feature in component.component_info.outputs: provided_features.append(feature)
             if len(all_components) == 0: all_components_orderd = True
 
-        pipe.pipe_components = correct_order_component_pipeline
+        pipe.components = correct_order_component_pipeline
 
         return pipe
 
@@ -426,7 +479,7 @@ class PipelineQueryVerifier():
         :param pipe: pipe to be configured
         :return: configured pipe
         '''
-        for c in pipe.pipe_components:
+        for c in pipe.components:
             if 'token' in c.component_info.spark_output_column_names: continue
             # if 'document' in c.component_info.inputs and 'sentence' not in c.component_info.inputs  :
             if 'document' in c.component_info.inputs and 'sentence' not in c.component_info.inputs and 'sentence' not in c.component_info.outputs:
@@ -458,7 +511,7 @@ class PipelineQueryVerifier():
         # here we could change the col name to doc_embedding potentially
         # 1. Configure every Annotator/Classifier that works on sentences to take in Document instead of sentence
         #  Note: This takes care of changing Sentence_embeddings to Document embeddings, since embedder runs on doc then.
-        for c in pipe.pipe_components:
+        for c in pipe.components:
             if 'token' in c.component_info.spark_output_column_names: continue
             if 'sentence' in c.component_info.inputs and 'document' not in c.component_info.inputs:
                 logger.info(f"Configuring C={c.component_info.name}  of Type={type(c.model)} input to document level")

--- a/setup.py
+++ b/setup.py
@@ -47,13 +47,12 @@ setup(
     # For a discussion on single-sourcing the version across setup.py and the
     # project code, see
     # https://packaging.python.org/en/latest/single_source_version.html
-    version='1.1.1',  # Required
+    version='1.1.3',  # Required
 
     # This is a one-line description or tagline of what your project does. This
     # corresponds to the "Summary" metadata field:
     # https://packaging.python.org/specifications/core-metadata/#summary
     description='John Snow Labs NLU provides state of the art algorithms for NLP&NLU with hundreds of pretrained models in 60+ languages. It enables swift and simple development and research with its powerful Pythonic and Keras inspired API. It is powerd by John Snow Labs powerful Spark NLP library.',
-
     # This is an optional longer description of your project that represents
     # the body of text which users will see when they visit PyPI.
     #
@@ -209,7 +208,7 @@ setup(
         ('', ['nlu/components/utils/deep_sentence_detector/component_infos.json']),
         ('', ['nlu/components/utils/document_assembler/component_infos.json']),
         ('', ['nlu/components/utils/sentence_detector/component_infos.json']),
-        ('', ['nlu/components/utils/sentence_embedding/component_infos.json']),
+        ('', ['nlu/components/utils/sentence_embeddings/component_infos.json']),
         ('', ['nlu/components/utils/ner_to_chunk_converter/component_infos.json']),
 
         ('', ['nlu/components/utils/token_assembler/component_infos.json']),

--- a/tests/nlu_core_tests/component_tests/classifier_tests/snips.py
+++ b/tests/nlu_core_tests/component_tests/classifier_tests/snips.py
@@ -1,0 +1,28 @@
+
+
+
+import unittest
+from nlu import *
+class TestCyber(unittest.TestCase):
+
+    def test_snips_classifer_model(self):
+        pipe = nlu.load('en.classify.snips',verbose=True)
+        df = pipe.predict(['I love pancaces. I hate Mondays', 'I love Fridays'])
+        print(df.columns)
+        for c in df.columns:print(c,df[c])
+
+    def test_snips_ner_model(self):
+        pipe = nlu.load('en.ner.snips',verbose=True)
+        df = pipe.predict(['I love pancaces. I hate Mondays', 'I love Fridays'])
+        print(df.columns)
+        for c in df.columns:print(c,df[c])
+
+    def test_quick(self):
+        pipe = nlu.load('bn.ner',verbose=True)
+        df = pipe.predict(['I love pancaces. I hate Mondays', 'I love Fridays'])
+        print(df.columns)
+        for c in df.columns:print(c,df[c])
+
+if __name__ == '__main__':
+    unittest.main()
+

--- a/tests/nlu_core_tests/namespace_tests.py
+++ b/tests/nlu_core_tests/namespace_tests.py
@@ -373,6 +373,9 @@ class TestNameSpace(unittest.TestCase):
     def test_26_bert(self):
         res = nlu.load('en.ner.bert',verbose=True).predict('The NLU library is a machine learning library, simmilar to Tensorflow and Keras')
         print(res)
+
+
+
 if __name__ == '__main__':
     unittest.main()
 

--- a/tests/nlu_core_tests/pipeline_tests/simple_pretrained_pipe_tests.py
+++ b/tests/nlu_core_tests/pipeline_tests/simple_pretrained_pipe_tests.py
@@ -15,7 +15,6 @@ class PretrainedPipeTests(unittest.TestCase):
         print(df.columns)
         print(df)
 
-
 if __name__ == '__main__':
     unittest.main()
 

--- a/tests/nlu_core_tests/training_tests/classifiers/classifier_dl_tests.py
+++ b/tests/nlu_core_tests/training_tests/classifiers/classifier_dl_tests.py
@@ -24,7 +24,7 @@ class ClassifierDlTests(unittest.TestCase):
         print(df.columns)
         print(df[['category','y']])
         print (classification_report(df['y'], df['category']))
-
+        pipe.save('/home/loan/Documents/freelance/jsl/nlu/nlu4realgit/tests/trained_models/quick_classifi')
 # Too heavy running on github actions
     # def test_classifier_dl_custom_embeds_doc_level(self):
     #     test_df = self.load_classifier_dl_dataset()


### PR DESCRIPTION
# Intent and Action Classification,  analyze Chinese News and the Crypto market, train a classifier that understands 100+ languages, translate between 200 + languages, answer questions, summarize text, and much more in NLU 1.1.3 

## NLU 1.1.3 Release Notes
We are very excited to announce that the latest NLU release comes with a new pretrained Intent Classifier and NER Action Extractor for text related to
music, restaurants, and movies trained on the SNIPS dataset. Make sure to check out the models hub and the easy 1-liners for more info!

In addition to that, new NER and Embedding models for Bengali are now available

Finally, there is a new NLU Webinar with 9 accompanying tutorial notebooks which teach you  a lot of things and is segmented into the following parts :

- Part1: Easy 1 Liners 
  - Spell checking/Sentiment/POS/NER/ BERTtology embeddings
- Part2: Data analysis and NLP tasks on [Crypto News Headline dataset](https://www.kaggle.com/kashnitsky/news-about-major-cryptocurrencies-20132018-40k)
  - Preprocessing and extracting Emotions, Keywords, Named Entities and visualize them
- Part3: NLU Multi-Lingual 1 Liners with [Microsoft's Marian Models](https://marian-nmt.github.io/publications/)
  - Translate between 200+ languages (and classify lang afterward)
- Part 4: Data analysis and NLP tasks on [Chinese News Article Dataset](https://github.com/JohnSnowLabs/nlu/blob/master/examples/webinars_conferences_etc/multi_lingual_webinar/4_Unsupervise_Chinese_Keyword_Extraction_NER_and_Translation_from_Chinese_News.ipynb)
  - Word Segmentation, Lemmatization, Extract Keywords, Named Entities and translate to english
- Part 5: Train a sentiment Classifier that understands 100+ Languages
  - Train on a french sentiment dataset and predict the sentiment of 100+ languages with [language-agnostic BERT Sentence Embedding](https://arxiv.org/abs/2007.01852)
- Part 6: Question answering, Summarization, Squad and more with [Google's T5](https://arxiv.org/abs/1910.10683)
  - T5 Question answering and 18 + other NLP tasks ([SQUAD](https://arxiv.org/abs/1606.05250) / [GLUE](https://arxiv.org/abs/1804.07461) / [SUPER GLUE](https://super.gluebenchmark.com/))


### New Models

#### NLU 1.1.3 New Non-English Models

| Language | nlu.load() reference                                         | Spark NLP Model reference                                    | Type                  |
| -------- | ------------------------------------------------------------ | ------------------------------------------------------------ | --------------------- |
| Bengali  | [bn.ner.cc_300d](https://nlp.johnsnowlabs.com/2021/02/10/bengali_cc_300d_bn.html) | [ bengaliner_cc_300d](https://nlp.johnsnowlabs.com/2021/02/10/bengali_cc_300d_bn.html) | NerDLModel    |
| Bengali  | [bn.embed](https://nlp.johnsnowlabs.com/2021/02/10/bengaliner_cc_300d_bn.html) | [bengali_cc_300d](https://nlp.johnsnowlabs.com/2021/02/10/bengaliner_cc_300d_bn.html) | NerDLModel            |
| Bengali  | [bn.embed.cc_300d](https://nlp.johnsnowlabs.com/2021/02/10/bengaliner_cc_300d_bn.html) | [bengali_cc_300d](https://nlp.johnsnowlabs.com/2021/02/10/bengaliner_cc_300d_bn.html) | Word Embeddings Model (Alias)    |
| Bengali  | [bn.embed.glove](https://nlp.johnsnowlabs.com/2021/02/10/bengaliner_cc_300d_bn.html) | [bengali_cc_300d](https://nlp.johnsnowlabs.com/2021/02/10/bengaliner_cc_300d_bn.html) |  Word Embeddings Model (Alias)|





#### NLU 1.1.3 New English Models

|Language | nlu.load() reference | Spark NLP Model reference | Type |
|---------|---------------------|----------------------------|------|
| English | [en.classify.snips](https://nlp.johnsnowlabs.com/2021/02/15/nerdl_snips_100d_en.html) |[nerdl_snips_100d](https://nlp.johnsnowlabs.com/2021/02/15/nerdl_snips_100d_en.html)     | NerDLModel |
| English | [en.ner.snips](https://nlp.johnsnowlabs.com/2021/02/15/classifierdl_use_snips_en.html) |[classifierdl_use_snips](https://nlp.johnsnowlabs.com/2021/02/15/classifierdl_use_snips_en.html)|ClassifierDLModel|




### New NLU Webinar
#### [State-of-the-art Natural Language Processing for 200+ Languages with 1 Line of code](https://events.johnsnowlabs.com/state-of-the-art-natural-language-processing-for-200-languages-with-1-line-of-code)


##### Talk Abstract 
Learn to harness the power of 1,000+ production-grade & scalable NLP models for 200+ languages - all available with just 1 line of Python code by leveraging the open-source NLU library, which is powered by the widely popular Spark NLP.

John Snow Labs has delivered over 80 releases of Spark NLP to date, making it the most widely used NLP library in the enterprise and providing the AI community with state-of-the-art accuracy and scale for a variety of common NLP tasks. The most recent releases include pre-trained models for over 200 languages - including languages that do not use spaces for word segmentation algorithms like Chinese, Japanese, and Korean, and languages written from right to left like Arabic, Farsi, Urdu, and Hebrew. All software and models are free and open source under an Apache 2.0 license.

This webinar will show you how to leverage the multi-lingual capabilities of Spark NLP & NLU - including automated language detection for up to 375 languages, and the ability to perform translation, named entity recognition, stopword removal, lemmatization, and more in a variety of language families. We will create Python code in real-time and solve these problems in just 30 minutes. The notebooks will then be made freely available online.

You can watch the [video here,](https://events.johnsnowlabs.com/state-of-the-art-natural-language-processing-for-200-languages-with-1-line-of-code) 

### NLU 1.1.3 New Notebooks and tutorials


#### New Webinar Notebooks

1. [NLU basics, easy 1-liners (Spellchecking, sentiment, NER, POS, BERT](https://github.com/JohnSnowLabs/nlu/blob/master/examples/webinars_conferences_etc/multi_lingual_webinar/0_liners_intro.ipynb)
2. [Analyze Crypto News dataset with Keyword extraction, NER, Emotional distribution, and stemming](https://github.com/JohnSnowLabs/nlu/blob/master/examples/webinars_conferences_etc/multi_lingual_webinar/1_NLU_base_features_on_dataset_with_YAKE_Lemma_Stemm_classifiers_NER_.ipynb)
3. [Translate Crypto News dataset between 300 Languages with the Marian Model (German, French, Hebrew examples)](https://github.com/JohnSnowLabs/nlu/blob/master/examples/webinars_conferences_etc/multi_lingual_webinar/2_multilingual_translation_with_marian_intro.ipynb)
4. [Translate Crypto News dataset between 300 Languages with the Marian Model (Hindi, Russian, Chinese examples)](https://github.com/JohnSnowLabs/nlu/blob/master/examples/webinars_conferences_etc/multi_lingual_webinar/3_more_multi_lingual_NLP_translation_Asian_languages_with_Marian.ipynb)
5. [Analyze Chinese News Headlines with Chinese Word Segmentation, Lemmatization, NER, and Keyword extraction](https://github.com/JohnSnowLabs/nlu/blob/master/examples/webinars_conferences_etc/multi_lingual_webinar/4_Unsupervise_Chinese_Keyword_Extraction_NER_and_Translation_from_Chinese_News.ipynb)
6. [Train a Sentiment Classifier that will understand 100+ languages on just a French Dataset with the powerful Language Agnostic Bert Embeddings](https://github.com/JohnSnowLabs/nlu/blob/master/examples/webinars_conferences_etc/multi_lingual_webinar/5_multi_lingual_sentiment_classifier_training_for_over_100_languages.ipynb)
7. [Summarize text and Answer Questions with T5](https://github.com/JohnSnowLabs/nlu/blob/master/examples/webinars_conferences_etc/multi_lingual_webinar/6_T5_question_answering_and_Text_summarization.ipynb)
8. [Solve any task in 1 line from SQUAD, GLUE and SUPER GLUE with T5](https://github.com/JohnSnowLabs/nlu/blob/master/examples/webinars_conferences_etc/multi_lingual_webinar/7_T5_SQUAD_GLUE_SUPER_GLUE_TASKS.ipynb)
9. [Overview of models for various languages](https://github.com/JohnSnowLabs/nlu/blob/master/examples/webinars_conferences_etc/multi_lingual_webinar/8_Multi_lingual_ner_pos_stop_words_sentiment_pretrained.ipynb)





#### New easy NLU 1-liners in NLU 1.1.3

####  [Detect actions in general commands related to music, restaurant, movies.](https://nlp.johnsnowlabs.com/2021/02/15/nerdl_snips_100d_en.html)


```python
nlu.load("en.classify.snips").predict("book a spot for nona gray  myrtle and alison at a top-rated brasserie that is distant from wilson av on nov  the 4th  2030 that serves ouzeri",output_level = "document")
```

outputs :

|                                               ner_confidence | entities                                                     | document                                                     | Entities_Classes                                             |
| -----------------------------------------------------------: | :----------------------------------------------------------- | :----------------------------------------------------------- | :----------------------------------------------------------- |
| [1.0, 1.0, 0.9997000098228455, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 0.9990000128746033, 1.0, 1.0, 1.0, 0.9965000152587891, 0.9998999834060669, 0.9567000269889832, 1.0, 1.0, 1.0, 0.9980000257492065, 0.9991999864578247, 0.9988999962806702, 1.0, 1.0, 0.9998999834060669] | ['nona gray myrtle and alison', 'top-rated', 'brasserie', 'distant', 'wilson av', 'nov the 4th 2030', 'ouzeri'] | book a spot for nona gray myrtle and alison at a top-rated brasserie that is distant from wilson av on nov the 4th 2030 that serves ouzeri | ['party_size_description', 'sort', 'restaurant_type', 'spatial_relation', 'poi', 'timeRange', 'cuisine'] |

####  [Named Entity Recognition (NER) Model in Bengali (bengaliner_cc_300d)](https://nlp.johnsnowlabs.com/2021/02/10/bengaliner_cc_300d_bn.html)


```python
# Bengali for: 'Iajuddin Ahmed passed Matriculation from Munshiganj High School in 1947 and Intermediate from Munshiganj Horganga College in 1950.'
nlu.load("bn.ner.cc_300d").predict("১৯৪৮ সালে ইয়াজউদ্দিন আহম্মেদ মুন্সিগঞ্জ উচ্চ বিদ্যালয় থেকে মেট্রিক পাশ করেন এবং ১৯৫০ সালে মুন্সিগঞ্জ হরগঙ্গা কলেজ থেকে ইন্টারমেডিয়েট পাশ করেন",output_level = "document")
```

outputs :

| ner_confidence                                                                                                                                                                                                                                                                                                                                                                                                                       | entities                                                                           | Entities_Classes   | document                                                                                                                         |
|---------------:|:-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|:-----------------------------------------------------------------------------------|:--------------------------------------|
| [0.9987999796867371, 0.9854000210762024, 0.8604000210762024, 0.6686999797821045, 0.5289999842643738, 0.7009999752044678, 0.7684999704360962, 0.9979000091552734, 0.9976000189781189, 0.9930999875068665, 0.9994000196456909, 0.9879000186920166, 0.7407000064849854, 0.9215999841690063, 0.7657999992370605, 0.39419999718666077, 0.9124000072479248, 0.9932000041007996, 0.9919999837875366, 0.995199978351593, 0.9991999864578247] | ['সালে', 'ইয়াজউদ্দিন আহম্মেদ', 'মুন্সিগঞ্জ উচ্চ বিদ্যালয়', 'সালে', 'মুন্সিগঞ্জ হরগঙ্গা কলেজ'] | ['TIME', 'PER', 'ORG', 'TIME', 'ORG'] | ১৯৪৮ সালে ইয়াজউদ্দিন আহম্মেদ মুন্সিগঞ্জ উচ্চ বিদ্যালয় থেকে মেট্রিক পাশ করেন এবং ১৯৫০ সালে মুন্সিগঞ্জ হরগঙ্গা কলেজ থেকে ইন্টারমেডিয়েট পাশ করেন |

#### [Identify intent in general text - SNIPS dataset](https://nlp.johnsnowlabs.com/2021/02/15/classifierdl_use_snips_en.html)


```python
nlu.load("en.ner.snips").predict("I want to bring six of us to a bistro in town that serves hot chicken sandwich that is within the same area",output_level = "document")
```

outputs :


| document | snips | snips_confidence|
|----------|------|------------------|
| I want to bring six of us to a bistro in town that serves hot chicken sandwich that is within the same area | BookRestaurant |                  1 |


#### [Word Embeddings for Bengali (bengali_cc_300d)](https://nlp.johnsnowlabs.com/2021/02/10/bengali_cc_300d_bn.html)




```python
# Bengali for : 'Iajuddin Ahmed passed Matriculation from Munshiganj High School in 1947 and Intermediate from Munshiganj Horganga College in 1950.'
nlu.load("bn.embed").predict("১৯৪৮ সালে ইয়াজউদ্দিন আহম্মেদ মুন্সিগঞ্জ উচ্চ বিদ্যালয় থেকে মেট্রিক পাশ করেন এবং ১৯৫০ সালে মুন্সিগঞ্জ হরগঙ্গা কলেজ থেকে ইন্টারমেডিয়েট পাশ করেন",output_level = "document")
```

outputs :

|                                                     document | bn_embed_embeddings                                          |
| -----------------------------------------------------------: | :----------------------------------------------------------- |
| ১৯৪৮ সালে ইয়াজউদ্দিন আহম্মেদ মুন্সিগঞ্জ উচ্চ বিদ্যালয় থেকে মেট্রিক পাশ করেন এবং ১৯৫০ সালে মুন্সিগঞ্জ হরগঙ্গা কলেজ থেকে ইন্টারমেডিয়েট পাশ করেন | [-0.0828      0.0683      0.0215     ...  0.0679     -0.0484...] |



### NLU 1.1.3 Enhancements
- Added automatic conversion  to Sentence Embeddings of Word Embeddings when there is no Sentence Embedding Avaiable and a model needs the converted version to run.


### NLU 1.1.3 Bug Fixes
- Fixed a bug that caused `ur.sentiment` NLU pipeline to build incorrectly
- Fixed a bug that caused `sentiment.imdb.glove` NLU pipeline to build incorrectly
- Fixed a bug that caused `en.sentiment.glove.imdb` NLU pipeline to build incorrectly
- Fixed a bug that caused Spark 2.3.X environments to crash.

### NLU Installation

```bash
# PyPi
!pip install nlu pyspark==2.4.7
#Conda
# Install NLU from Anaconda/Conda
conda install -c johnsnowlabs nlu
```

### Additional NLU ressources

- [NLU Website](https://nlu.johnsnowlabs.com/)
- [All NLU Tutorial Notebooks](https://nlu.johnsnowlabs.com/docs/en/notebooks)
- [NLU Videos and Blogposts on NLU](https://nlp.johnsnowlabs.com/learn#pythons-nlu-library)
- [NLU on Github](https://github.com/JohnSnowLabs/nlu)
- [Suggestions or Questions? Contact us in Slack!](https://join.slack.com/t/spark-nlp/shared_invite/zt-lutct9gm-kuUazcyFKhuGY3_0AMkxqA)

