### PR TITLE
Sentence Embedding Visualizations, 20+ New Models, 2 New Trainable Models, Drug Normalizer and more in John Snow Labs NLU 3.1.1

### DIFF
--- a/docs/en/streamlit_viz_examples.md
+++ b/docs/en/streamlit_viz_examples.md
@@ -72,11 +72,15 @@ streamlit run https://raw.githubusercontent.com/JohnSnowLabs/nlu/master/examples
 streamlit run https://raw.githubusercontent.com/JohnSnowLabs/nlu/master/examples/streamlit/06_token_features.py
 ```
 
-### Example:  [`07_token_embedding_dimension_reduction`](https://raw.githubusercontent.com/JohnSnowLabs/nlu/master/examples/streamlit/07_token_embedding_manifolds)
+### Example:  [`07_token_embedding_dimension_reduction`](https://raw.githubusercontent.com/JohnSnowLabs/nlu/master/examples/streamlit/07_token_embedding_manifolds.py)
 ```shell
 streamlit run https://raw.githubusercontent.com/JohnSnowLabs/nlu/master/examples/streamlit/07_token_embedding_manifolds.py
 ```
 
+### Example:  [`08_token_embedding_dimension_reduction`](https://raw.githubusercontent.com/JohnSnowLabs/nlu/master/examples/streamlit/08_sentence_embedding_manifolds.py==)
+```shell
+streamlit run https://raw.githubusercontent.com/JohnSnowLabs/nlu/master/examples/streamlit/08_sentence_embedding_manifolds.py
+```
 
 ## How to use NLU?
 All you need to know about NLU is that there is the [`nlu.load()`](https://nlu.johnsnowlabs.com/docs/en/load_api) method which returns a `NLUPipeline` object
@@ -329,12 +333,9 @@ nlu.load('bert').viz_streamlit_word_similarity(['I love love loooove NLU! <3','I
 
 
 
+# Embedding visualization via Manifold and Matrix Decomposition algorithms
 
-
-
-## Streamlit Word Embedding visualization via Manifold and Matrix Decomposition algorithms
-
-### <kbd>function</kbd> `pipe.viz_streamlit_word_embed_manifold`
+## <kbd>function</kbd> `pipe.viz_streamlit_word_embed_manifold`
 
 Visualize Word Embeddings in `1-D`, `2-D`, or `3-D` by `Reducing Dimensionality` via 11 Supported methods from  [Manifold Algorithms](https://scikit-learn.org/stable/modules/classes.html#module-sklearn.manifold)
 and [Matrix Decomposition Algorithms](https://scikit-learn.org/stable/modules/classes.html#module-sklearn.decomposition).
@@ -388,14 +389,58 @@ nlu.load('bert',verbose=True).viz_streamlit_word_embed_manifold(default_texts=['
 <img  src="https://github.com/JohnSnowLabs/nlu/blob/master/docs/assets/streamlit_docs_assets/gif/word_embed_dimension_reduction/big_example_word_embedding_dimension_reduction.gif?raw=true">
 
 
-### [Supported Manifold Algorithms ](https://scikit-learn.org/stable/modules/classes.html#module-sklearn.manifold)
+
+
+## <kbd>function</kbd> `pipe.viz_streamlit_sentence_embed_manifold`
+
+Visualize Sentence Embeddings in `1-D`, `2-D`, or `3-D` by `Reducing Dimensionality` via 12 Supported methods from  [Manifold Algorithms](https://scikit-learn.org/stable/modules/classes.html#module-sklearn.manifold)
+and [Matrix Decomposition Algorithms](https://scikit-learn.org/stable/modules/classes.html#module-sklearn.decomposition).
+Additionally, you can color the lower dimensional points with a label that has been previously assigned to the text by specifying a list of nlu references in the `additional_classifiers_for_coloring` parameter.
+You can also select additional classifiers via the GUI.
+
+- Reduces Dimensionality of high dimensional Sentence Embeddings to `1-D`, `2-D`, or `3-D` and plot the resulting data in an interactive `Plotly` plot
+- Applicable with [any of the 100+ Sentence Embedding models](https://nlp.johnsnowlabs.com/models?task=Embeddings)
+- Color points by classifying with any of the 100+ [Document Classifiers](https://nlp.johnsnowlabs.com/models?task=Text+Classification)
+- Gemerates `NUM-DIMENSIONS` * `NUM-EMBEDDINGS` * `NUM-DIMENSION-REDUCTION-ALGOS` plots
+
+```python
+nlu.load('embed_sentence.bert').viz_streamlit_sentence_embed_manifold(['text1','text2tdo'])
+```
+
+<img  src="https://github.com/JohnSnowLabs/nlu/blob/master/docs/assets/streamlit_docs_assets/gif/sentence_embedding_dimension_reduction/sentence_manifold_low_qual.gif?raw=true">
+
+### <kbd>function parameters</kbd> `pipe.viz_streamlit_sentence_embed_manifold`
+| Argument    | Type        |                                                            Default         |Description |
+|----------------------------|------------|-----------------------------------------------------------|---------------------------------------------------------|
+|`default_texts`|                    `List[str]`  | ("Donald Trump likes to party!", "Angela Merkel likes to party!", 'Peter HATES TO PARTTY!!!! :(') | List of strings to apply classifiers, embeddings, and manifolds to. |  
+| `text`                                         | `Optional[str]`   |     `'Billy likes to swim'`                 | Text to predict classes for. |   
+|`sub_title`|                    `Optional[str]` | "Apply any of the 11 `Manifold` or `Matrix Decomposition` algorithms to reduce the dimensionality of `Sentence Embeddings` to `1-D`, `2-D` and `3-D` " | Sub title of the Streamlit app |   
+|`default_algos_to_apply`|           `List[str]` | `["TSNE", "PCA"]` | A list Manifold and Matrix Decomposition Algorithms to apply. Can be either `'TSNE'`,`'ISOMAP'`,`'LLE'`,`'Spectral Embedding'`, `'MDS'`,`'PCA'`,`'SVD aka LSA'`,`'DictionaryLearning'`,`'FactorAnalysis'`,`'FastICA'` or `'KernelPCA'`, |   
+|`target_dimensions`|              `List[int]`   | `(1,2,3)` | Defines the target dimension embeddings will be reduced to |
+|`show_algo_select`|               `bool`        | `True`  | Show selector for Manifold and Matrix Decomposition Algorithms |   
+|`show_embed_select`|              `bool`        | `True` | Show selector for Embedding Selection |  
+|`show_color_select`|              `bool`        | `True` | Show selector for coloring plots  |
+|`display_embed_information`                     | `bool`              |  `True`                         | Show additional embedding information like `dimension`, `nlu_reference`, `spark_nlp_reference`, `sotrage_reference`, `modelhub link` and more.|  
+| `set_wide_layout_CSS`                          |  `bool`                                                             |  `True`                                                                                   | Whether to inject custom CSS or not.|  
+|`num_cols`                                      | `int`               |  `2`                            |  How many columns should for the layout in streamlit when rendering the similarity matrixes.|  
+|     `key`                                      |  `str`              | `"NLU_streamlit"`               | Key for the Streamlit elements drawn  |
+|`additional_classifiers_for_coloring`           |         `List[str]`|`['sentiment.imdb']` | List of additional NLU references to load for generting hue colors  |
+| `show_model_select`                            |  `bool`                                          | `True`                                                                                 | Show a model selection dropdowns that makes any of the 1000+ models avaiable in 1 click  |
+| `model_select_position`                        |  `str`                                                             |   `'side'`            | [Whether to output the positions of predictions or not, see `pipe.predict(positions=true`) for more info](https://nlu.johnsnowlabs.com/docs/en/predict_api#output-positions-parameter)  |   
+| `show_logo`                                    |  `bool`                                            | `True`                                                                                   | Show logo  |
+| `display_infos`                                |  `bool`                                            | `False`                                                                                  | Display additonal information about ISO codes and the NLU namespace structure.|  
+| `n_jobs`                                       |          `Optional[int]` | `3`|   `False` | How many cores to use for paralellzing when using Sklearn Dimension Reduction algorithms.  |  
+
+
+
+### [Supported Manifold Algorithms for Word and Sentence Embeddings](https://scikit-learn.org/stable/modules/classes.html#module-sklearn.manifold)
 - [TSNE](https://scikit-learn.org/stable/modules/generated/sklearn.manifold.TSNE.html#sklearn.manifold.TSNE)
 - [ISOMAP](https://scikit-learn.org/stable/modules/generated/sklearn.manifold.Isomap.html#sklearn.manifold.Isomap)
 - [LLE](https://scikit-learn.org/stable/modules/generated/sklearn.manifold.LocallyLinearEmbedding.html#sklearn.manifold.LocallyLinearEmbedding)
 - [Spectral Embedding](https://scikit-learn.org/stable/modules/generated/sklearn.manifold.SpectralEmbedding.html#sklearn.manifold.SpectralEmbedding)
 - [MDS](https://scikit-learn.org/stable/modules/generated/sklearn.manifold.MDS.html#sklearn.manifold.MDS)
 
-### [Supported Matrix Decomposition Algorithms ](https://scikit-learn.org/stable/modules/classes.html#module-sklearn.decomposition)
+### [Supported Matrix Decomposition Algorithms for Word and Sentence Embeddings](https://scikit-learn.org/stable/modules/classes.html#module-sklearn.decomposition)
 - [PCA](https://scikit-learn.org/stable/modules/generated/sklearn.decomposition.PCA.html#sklearn.decomposition.PCA)
 - [Truncated SVD aka LSA](https://scikit-learn.org/stable/modules/generated/sklearn.decomposition.TruncatedSVD.html#sklearn.decomposition.TruncatedSVD)
 - [DictionaryLearning](https://scikit-learn.org/stable/modules/generated/sklearn.decomposition.DictionaryLearning.html#sklearn.decomposition.DictionaryLearning)
@@ -403,9 +448,6 @@ nlu.load('bert',verbose=True).viz_streamlit_word_embed_manifold(default_texts=['
 - [FastICA](https://scikit-learn.org/stable/modules/generated/fastica-function.html#sklearn.decomposition.fastica)
 - [KernelPCA](https://scikit-learn.org/stable/modules/generated/sklearn.decomposition.KernelPCA.html#sklearn.decomposition.KernelPCA)
 - [Latent Dirichlet Allocation](https://scikit-learn.org/stable/modules/generated/sklearn.decomposition.LatentDirichletAllocation.html)
-
-
-
 
 
 </div>

--- a/docs/en/training.md
+++ b/docs/en/training.md
@@ -160,8 +160,8 @@ trained_chunk_resolver.predict(df)
 
 ### Train with custom embeddings
 ```python
-# Use BIo GLove
-untrained_chunk_resolver = nlu.load('en.embed.glove.biovec train.resolve_chunks')
+# Use Healthcare Embeddings
+trainable_pipe = nlu.load('en.embed.glove.healthcare_100d train.resolve_chunks')
 trained_chunk_resolver  =  untrained_chunk_resolver.fit(df)
 trained_chunk_resolver.predict(df)
  ```

--- a/examples/streamlit/README.md
+++ b/examples/streamlit/README.md
@@ -45,7 +45,6 @@ streamlit run https://raw.githubusercontent.com/JohnSnowLabs/nlu/master/examples
 streamlit run https://raw.githubusercontent.com/JohnSnowLabs/nlu/master/examples/streamlit/03_text_similarity_matrix.py
 ```
 
-
 ### Example:  [`04_dependency_tree`](https://raw.githubusercontent.com/JohnSnowLabs/nlu/master/examples/streamlit/04_dependency_tree.py)
 ```shell
 streamlit run https://raw.githubusercontent.com/JohnSnowLabs/nlu/master/examples/streamlit/04_dependency_tree.py
@@ -66,6 +65,10 @@ streamlit run https://raw.githubusercontent.com/JohnSnowLabs/nlu/master/examples
 streamlit run https://raw.githubusercontent.com/JohnSnowLabs/nlu/master/examples/streamlit/07_token_embedding_manifolds.py
 ```
 
+### Example:  [`08_token_embedding_dimension_reduction`](https://raw.githubusercontent.com/JohnSnowLabs/nlu/master/examples/streamlit/08_sentence_embedding_manifolds.py==)
+```shell
+streamlit run https://raw.githubusercontent.com/JohnSnowLabs/nlu/master/examples/streamlit/08_sentence_embedding_manifolds.py
+```
 
 ## How to use NLU?
 All you need to know about NLU is that there is the [`nlu.load()`](https://nlu.johnsnowlabs.com/docs/en/load_api) method which returns a `NLUPipeline` object
@@ -317,9 +320,9 @@ nlu.load('bert').viz_streamlit_word_similarity(['I love love loooove NLU! <3','I
 
 
 
-## Streamlit Word Embedding visualization via Manifold and Matrix Decomposition algorithms
+# Embedding visualization via Manifold and Matrix Decomposition algorithms
 
-### <kbd>function</kbd> `pipe.viz_streamlit_word_embed_manifold`
+## <kbd>function</kbd> `pipe.viz_streamlit_word_embed_manifold`
 
 Visualize Word Embeddings in `1-D`, `2-D`, or `3-D` by `Reducing Dimensionality` via 11 Supported methods from  [Manifold Algorithms](https://scikit-learn.org/stable/modules/classes.html#module-sklearn.manifold)
 and [Matrix Decomposition Algorithms](https://scikit-learn.org/stable/modules/classes.html#module-sklearn.decomposition).
@@ -333,7 +336,7 @@ Additionally, you can color the lower dimensional points with a label that has b
 
 
 ```python
-nlu.load('bert',verbose=True).viz_streamlit_word_embed_manifold(default_texts=THE_MATRIX_ARCHITECT_SCRIPT.split('\n'),default_algos_to_apply=['TSNE'],MAX_DISPLAY_NUM=5)
+nlu.load('bert',verbose=True).viz_streamlit_word_embed_manifold(default_texts=['I love NLU <3',  'I love streamlit <3'],default_algos_to_apply=['TSNE'],MAX_DISPLAY_NUM=5)
 ```
 
 <img  src="https://github.com/JohnSnowLabs/nlu/blob/master/docs/assets/streamlit_docs_assets/gif/word_embed_dimension_reduction/manifold_intro.gif?raw=true">
@@ -345,43 +348,91 @@ nlu.load('bert',verbose=True).viz_streamlit_word_embed_manifold(default_texts=TH
 
 | Argument    | Type        |                                                            Default         |Description |
 |----------------------------|------------|-----------------------------------------------------------|---------------------------------------------------------|
-|`default_texts`|          `List[str]`  | ("Donald Trump likes to party!", "Angela Merkel likes to party!", 'Peter HATES TO PARTTY!!!! :(') | List of strings to apply classifiers, embeddings, and manifolds to. |  
-| `text`                    | `Optional[str]`   |     `'Billy likes to swim'`                 | Text to predict classes for. |   
-|`sub_title`|         ` Optional[str]` | "Apply any of the 11 `Manifold` or `Matrix Decomposition` algorithms to reduce the dimensionality of `Word Embeddings` to `1-D`, `2-D` and `3-D` " | Sub title of the Streamlit app |   
+|`default_texts`|                    `List[str]`  | ("Donald Trump likes to party!", "Angela Merkel likes to party!", 'Peter HATES TO PARTTY!!!! :(') | List of strings to apply classifiers, embeddings, and manifolds to. |  
+| `text`                                         | `Optional[str]`   |     `'Billy likes to swim'`                 | Text to predict classes for. |   
+|`sub_title`|                    `Optional[str]` | "Apply any of the 11 `Manifold` or `Matrix Decomposition` algorithms to reduce the dimensionality of `Word Embeddings` to `1-D`, `2-D` and `3-D` " | Sub title of the Streamlit app |   
 |`default_algos_to_apply`|           `List[str]` | `["TSNE", "PCA"]` | A list Manifold and Matrix Decomposition Algorithms to apply. Can be either `'TSNE'`,`'ISOMAP'`,`'LLE'`,`'Spectral Embedding'`, `'MDS'`,`'PCA'`,`'SVD aka LSA'`,`'DictionaryLearning'`,`'FactorAnalysis'`,`'FastICA'` or `'KernelPCA'`, |   
-|`target_dimensions`|          `List[int]` | `(1,2,3)` | Defines the target dimension embeddings will be reduced to |   
-|`show_algo_select`|          `bool` | `True`  | Show selector for Manifold and Matrix Decomposition Algorithms |   
-|`show_embed_select`|          `bool` | `True` | Show selector for Embedding Selection |  
-|`show_color_select`|          `bool` | `True` | Show selector for coloring plots  |
-|`MAX_DISPLAY_NUM`|         `int`|`100` | Cap maximum number of Tokens displayed  |
-|`display_embed_information`              | `bool`              |  `True`                         | Show additional embedding information like `dimension`, `nlu_reference`, `spark_nlp_reference`, `sotrage_reference`, `modelhub link` and more.|  
-| `set_wide_layout_CSS`      |  `bool`                                                             |  `True`                                                                                   | Whether to inject custom CSS or not.|  
-|`num_cols`                               | `int`               |  `2`                            |  How many columns should for the layout in streamlit when rendering the similarity matrixes.|  
-|     `key`                               |  `str`              | `"NLU_streamlit"`               | Key for the Streamlit elements drawn  |
-|`additional_classifiers_for_coloring`|         `List[str]`|`['pos', 'sentiment.imdb']` | List of additional NLU references to load for generting hue colors  |
-| `show_model_select`        |  `bool`                                          | `True`                                                                                 | Show a model selection dropdowns that makes any of the 1000+ models avaiable in 1 click  |
-| `model_select_position`    |  `str`                                                             |   `'side'`            | [Whether to output the positions of predictions or not, see `pipe.predict(positions=true`) for more info](https://nlu.johnsnowlabs.com/docs/en/predict_api#output-positions-parameter)  |   
-| `show_logo`             |  `bool`                                            | `True`                                                                                   | Show logo  |
-| `display_infos`         |  `bool`                                            | `False`                                                                                  | Display additonal information about ISO codes and the NLU namespace structure.|  
-| `n_jobs`|          `Optional[int]` | `3`|   `False` | How many cores to use for paralellzing when using Sklearn Dimension Reduction algorithms.  |  
+|`target_dimensions`|              `List[int]`   | `(1,2,3)` | Defines the target dimension embeddings will be reduced to |
+|`show_algo_select`|               `bool`        | `True`  | Show selector for Manifold and Matrix Decomposition Algorithms |   
+|`show_embed_select`|              `bool`        | `True` | Show selector for Embedding Selection |  
+|`show_color_select`|              `bool`        | `True` | Show selector for coloring plots  |
+|`MAX_DISPLAY_NUM`|                  `int`       |`100` | Cap maximum number of Tokens displayed  |
+|`display_embed_information`                     | `bool`              |  `True`                         | Show additional embedding information like `dimension`, `nlu_reference`, `spark_nlp_reference`, `sotrage_reference`, `modelhub link` and more.|  
+| `set_wide_layout_CSS`                          |  `bool`                                                             |  `True`                                                                                   | Whether to inject custom CSS or not.|  
+|`num_cols`                                      | `int`               |  `2`                            |  How many columns should for the layout in streamlit when rendering the similarity matrixes.|  
+|     `key`                                      |  `str`              | `"NLU_streamlit"`               | Key for the Streamlit elements drawn  |
+|`additional_classifiers_for_coloring`           |         `List[str]`|`['pos', 'sentiment.imdb']` | List of additional NLU references to load for generting hue colors  |
+| `show_model_select`                            |  `bool`                                          | `True`                                                                                 | Show a model selection dropdowns that makes any of the 1000+ models avaiable in 1 click  |
+| `model_select_position`                        |  `str`                                                             |   `'side'`            | [Whether to output the positions of predictions or not, see `pipe.predict(positions=true`) for more info](https://nlu.johnsnowlabs.com/docs/en/predict_api#output-positions-parameter)  |   
+| `show_logo`                                    |  `bool`                                            | `True`                                                                                   | Show logo  |
+| `display_infos`                                |  `bool`                                            | `False`                                                                                  | Display additonal information about ISO codes and the NLU namespace structure.|  
+| `n_jobs`                                       |          `Optional[int]` | `3`|   `False` | How many cores to use for paralellzing when using Sklearn Dimension Reduction algorithms.  |  
+
+
+
 
 ### Larger Example showcasing more dimension reduction techniques on a larger corpus :
 
 <img  src="https://github.com/JohnSnowLabs/nlu/blob/master/docs/assets/streamlit_docs_assets/gif/word_embed_dimension_reduction/big_example_word_embedding_dimension_reduction.gif?raw=true">
 
 
-### [Supported Manifold Algorithms ](https://scikit-learn.org/stable/modules/classes.html#module-sklearn.manifold)
+
+
+## <kbd>function</kbd> `pipe.viz_streamlit_sentence_embed_manifold`
+
+Visualize Sentence Embeddings in `1-D`, `2-D`, or `3-D` by `Reducing Dimensionality` via 12 Supported methods from  [Manifold Algorithms](https://scikit-learn.org/stable/modules/classes.html#module-sklearn.manifold)
+and [Matrix Decomposition Algorithms](https://scikit-learn.org/stable/modules/classes.html#module-sklearn.decomposition).
+Additionally, you can color the lower dimensional points with a label that has been previously assigned to the text by specifying a list of nlu references in the `additional_classifiers_for_coloring` parameter.
+You can also select additional classifiers via the GUI.
+
+- Reduces Dimensionality of high dimensional Sentence Embeddings to `1-D`, `2-D`, or `3-D` and plot the resulting data in an interactive `Plotly` plot
+- Applicable with [any of the 100+ Sentence Embedding models](https://nlp.johnsnowlabs.com/models?task=Embeddings)
+- Color points by classifying with any of the 100+ [Document Classifiers](https://nlp.johnsnowlabs.com/models?task=Text+Classification)
+- Gemerates `NUM-DIMENSIONS` * `NUM-EMBEDDINGS` * `NUM-DIMENSION-REDUCTION-ALGOS` plots
+
+```python
+nlu.load('embed_sentence.bert').viz_streamlit_sentence_embed_manifold(['text1','text2tdo'])
+```
+
+<img  src="https://github.com/JohnSnowLabs/nlu/blob/master/docs/assets/streamlit_docs_assets/gif/sentence_embedding_dimension_reduction/sentence_manifold_low_qual.gif?raw=true">
+
+### <kbd>function parameters</kbd> `pipe.viz_streamlit_sentence_embed_manifold`
+| Argument    | Type        |                                                            Default         |Description |
+|----------------------------|------------|-----------------------------------------------------------|---------------------------------------------------------|
+|`default_texts`|                    `List[str]`  | ("Donald Trump likes to party!", "Angela Merkel likes to party!", 'Peter HATES TO PARTTY!!!! :(') | List of strings to apply classifiers, embeddings, and manifolds to. |  
+| `text`                                         | `Optional[str]`   |     `'Billy likes to swim'`                 | Text to predict classes for. |   
+|`sub_title`|                    `Optional[str]` | "Apply any of the 11 `Manifold` or `Matrix Decomposition` algorithms to reduce the dimensionality of `Sentence Embeddings` to `1-D`, `2-D` and `3-D` " | Sub title of the Streamlit app |   
+|`default_algos_to_apply`|           `List[str]` | `["TSNE", "PCA"]` | A list Manifold and Matrix Decomposition Algorithms to apply. Can be either `'TSNE'`,`'ISOMAP'`,`'LLE'`,`'Spectral Embedding'`, `'MDS'`,`'PCA'`,`'SVD aka LSA'`,`'DictionaryLearning'`,`'FactorAnalysis'`,`'FastICA'` or `'KernelPCA'`, |   
+|`target_dimensions`|              `List[int]`   | `(1,2,3)` | Defines the target dimension embeddings will be reduced to |
+|`show_algo_select`|               `bool`        | `True`  | Show selector for Manifold and Matrix Decomposition Algorithms |   
+|`show_embed_select`|              `bool`        | `True` | Show selector for Embedding Selection |  
+|`show_color_select`|              `bool`        | `True` | Show selector for coloring plots  |
+|`display_embed_information`                     | `bool`              |  `True`                         | Show additional embedding information like `dimension`, `nlu_reference`, `spark_nlp_reference`, `sotrage_reference`, `modelhub link` and more.|  
+| `set_wide_layout_CSS`                          |  `bool`                                                             |  `True`                                                                                   | Whether to inject custom CSS or not.|  
+|`num_cols`                                      | `int`               |  `2`                            |  How many columns should for the layout in streamlit when rendering the similarity matrixes.|  
+|     `key`                                      |  `str`              | `"NLU_streamlit"`               | Key for the Streamlit elements drawn  |
+|`additional_classifiers_for_coloring`           |         `List[str]`|`['sentiment.imdb']` | List of additional NLU references to load for generting hue colors  |
+| `show_model_select`                            |  `bool`                                          | `True`                                                                                 | Show a model selection dropdowns that makes any of the 1000+ models avaiable in 1 click  |
+| `model_select_position`                        |  `str`                                                             |   `'side'`            | [Whether to output the positions of predictions or not, see `pipe.predict(positions=true`) for more info](https://nlu.johnsnowlabs.com/docs/en/predict_api#output-positions-parameter)  |   
+| `show_logo`                                    |  `bool`                                            | `True`                                                                                   | Show logo  |
+| `display_infos`                                |  `bool`                                            | `False`                                                                                  | Display additonal information about ISO codes and the NLU namespace structure.|  
+| `n_jobs`                                       |          `Optional[int]` | `3`|   `False` | How many cores to use for paralellzing when using Sklearn Dimension Reduction algorithms.  |  
+
+
+
+### [Supported Manifold Algorithms for Word and Sentence Embeddings](https://scikit-learn.org/stable/modules/classes.html#module-sklearn.manifold)
 - [TSNE](https://scikit-learn.org/stable/modules/generated/sklearn.manifold.TSNE.html#sklearn.manifold.TSNE)
 - [ISOMAP](https://scikit-learn.org/stable/modules/generated/sklearn.manifold.Isomap.html#sklearn.manifold.Isomap)
 - [LLE](https://scikit-learn.org/stable/modules/generated/sklearn.manifold.LocallyLinearEmbedding.html#sklearn.manifold.LocallyLinearEmbedding)
 - [Spectral Embedding](https://scikit-learn.org/stable/modules/generated/sklearn.manifold.SpectralEmbedding.html#sklearn.manifold.SpectralEmbedding)
 - [MDS](https://scikit-learn.org/stable/modules/generated/sklearn.manifold.MDS.html#sklearn.manifold.MDS)
 
-### [Supported Matrix Decomposition Algorithms ](https://scikit-learn.org/stable/modules/classes.html#module-sklearn.decomposition)
+### [Supported Matrix Decomposition Algorithms for Word and Sentence Embeddings](https://scikit-learn.org/stable/modules/classes.html#module-sklearn.decomposition)
 - [PCA](https://scikit-learn.org/stable/modules/generated/sklearn.decomposition.PCA.html#sklearn.decomposition.PCA)
 - [Truncated SVD aka LSA](https://scikit-learn.org/stable/modules/generated/sklearn.decomposition.TruncatedSVD.html#sklearn.decomposition.TruncatedSVD)
 - [DictionaryLearning](https://scikit-learn.org/stable/modules/generated/sklearn.decomposition.DictionaryLearning.html#sklearn.decomposition.DictionaryLearning)
 - [FactorAnalysis](https://scikit-learn.org/stable/modules/generated/sklearn.decomposition.FactorAnalysis.html#sklearn.decomposition.FactorAnalysis)
 - [FastICA](https://scikit-learn.org/stable/modules/generated/fastica-function.html#sklearn.decomposition.fastica)
 - [KernelPCA](https://scikit-learn.org/stable/modules/generated/sklearn.decomposition.KernelPCA.html#sklearn.decomposition.KernelPCA)
+- [Latent Dirichlet Allocation](https://scikit-learn.org/stable/modules/generated/sklearn.decomposition.LatentDirichletAllocation.html)
 

--- a/tests/nlu_hc_tests/training_tests/chunk_resolution/chunk_resolver_tests.py
+++ b/tests/nlu_hc_tests/training_tests/chunk_resolution/chunk_resolver_tests.py
@@ -58,7 +58,7 @@ class ChunkResolverTrainingTests(unittest.TestCase):
         # trainable_pipe = nlu.load('glove train.resolve_chunks', verbose=True)
         # trainable_pipe = nlu.load('bert train.resolve_chunks', verbose=True)
         # trainable_pipe = nlu.load('bert train.resolve_chunks', verbose=True)
-        trainable_pipe = nlu.load('en.embed.glove.biovec train.resolve_chunks')
+        trainable_pipe = nlu.load('en.embed.glove.healthcare_100d train.resolve_chunks')
         trainable_pipe['chunk_resolver'].setNeighbours(350)
 
         # TODO bert/elmo give wierd storage ref errors...


### PR DESCRIPTION
# Sentence Embedding Visualizations, 20+ New Models, 2 New Trainable Models, Drug Normalizer and more in John Snow Labs NLU 3.1.1

We are very excited to announce NLU 3.1.1 has been released!   
It features a new Sentence Embedding visualization component for Streamlit which supports all 10+ previous dimension
reduction techniques. Additionally, all embedding visualizations now support [Latent Dirichlet Allocation](https://scikit-learn.org/stable/modules/generated/sklearn.decomposition.LatentDirichletAllocation.html) for dimension reduction.
Finally, 2 new trainable models for NER and chunk resolution are supported, a new drug normalizer algorithm has been added,
20+ new pre-trained models including Multi-Lingual, German,
various healthcare models and improved NER defaults when using licensed models that have NER dependencies.

## Streamlit Sentence Embedding visualization via Manifold and Matrix Decomposition algorithms

### <kbd>function</kbd> `pipe.viz_streamlit_sentence_embed_manifold`

Visualize Sentence Embeddings in `1-D`, `2-D`, or `3-D` by `Reducing Dimensionality` via 12 Supported methods from  [Manifold Algorithms](https://scikit-learn.org/stable/modules/classes.html#module-sklearn.manifold)
and [Matrix Decomposition Algorithms](https://scikit-learn.org/stable/modules/classes.html#module-sklearn.decomposition).
Additionally, you can color the lower dimensional points with a label that has been previously assigned to the text by specifying a list of nlu references in the `additional_classifiers_for_coloring` parameter.
You can also select additional classifiers via the GUI.

- Reduces Dimensionality of high dimensional Sentence Embeddings to `1-D`, `2-D`, or `3-D` and plot the resulting data in an interactive `Plotly` plot
- Applicable with [any of the 100+ Sentence Embedding models](https://nlp.johnsnowlabs.com/models?task=Embeddings)
- Color points by classifying with any of the 100+ [Document Classifiers](https://nlp.johnsnowlabs.com/models?task=Text+Classification)
- Gemerates `NUM-DIMENSIONS` * `NUM-EMBEDDINGS` * `NUM-DIMENSION-REDUCTION-ALGOS` plots

```python
nlu.load('embed_sentence.bert').viz_streamlit_sentence_embed_manifold(['text1','text2tdo'])
```

<img  src="https://github.com/JohnSnowLabs/nlu/blob/master/docs/assets/streamlit_docs_assets/gif/sentence_embedding_dimension_reduction/sentence_manifold_low_qual.gif?raw=true">

### <kbd>function parameters</kbd> `pipe.viz_streamlit_sentence_embed_manifold`
| Argument    | Type        |                                                            Default         |Description |
|----------------------------|------------|-----------------------------------------------------------|---------------------------------------------------------|
|`default_texts`|                    `List[str]`  | ("Donald Trump likes to party!", "Angela Merkel likes to party!", 'Peter HATES TO PARTTY!!!! :(') | List of strings to apply classifiers, embeddings, and manifolds to. |  
| `text`                                         | `Optional[str]`   |     `'Billy likes to swim'`                 | Text to predict classes for. |   
|`sub_title`|                    `Optional[str]` | "Apply any of the 11 `Manifold` or `Matrix Decomposition` algorithms to reduce the dimensionality of `Sentence Embeddings` to `1-D`, `2-D` and `3-D` " | Sub title of the Streamlit app |   
|`default_algos_to_apply`|           `List[str]` | `["TSNE", "PCA"]` | A list Manifold and Matrix Decomposition Algorithms to apply. Can be either `'TSNE'`,`'ISOMAP'`,`'LLE'`,`'Spectral Embedding'`, `'MDS'`,`'PCA'`,`'SVD aka LSA'`,`'DictionaryLearning'`,`'FactorAnalysis'`,`'FastICA'` or `'KernelPCA'`, |   
|`target_dimensions`|              `List[int]`   | `(1,2,3)` | Defines the target dimension embeddings will be reduced to |
|`show_algo_select`|               `bool`        | `True`  | Show selector for Manifold and Matrix Decomposition Algorithms |   
|`show_embed_select`|              `bool`        | `True` | Show selector for Embedding Selection |  
|`show_color_select`|              `bool`        | `True` | Show selector for coloring plots  |
|`display_embed_information`                     | `bool`              |  `True`                         | Show additional embedding information like `dimension`, `nlu_reference`, `spark_nlp_reference`, `sotrage_reference`, `modelhub link` and more.|  
| `set_wide_layout_CSS`                          |  `bool`                                                             |  `True`                                                                                   | Whether to inject custom CSS or not.|  
|`num_cols`                                      | `int`               |  `2`                            |  How many columns should for the layout in streamlit when rendering the similarity matrixes.|  
|     `key`                                      |  `str`              | `"NLU_streamlit"`               | Key for the Streamlit elements drawn  |
|`additional_classifiers_for_coloring`           |         `List[str]`|`['sentiment.imdb']` | List of additional NLU references to load for generting hue colors  |
| `show_model_select`                            |  `bool`                                          | `True`                                                                                 | Show a model selection dropdowns that makes any of the 1000+ models avaiable in 1 click  |
| `model_select_position`                        |  `str`                                                             |   `'side'`            | [Whether to output the positions of predictions or not, see `pipe.predict(positions=true`) for more info](https://nlu.johnsnowlabs.com/docs/en/predict_api#output-positions-parameter)  |   
| `show_logo`                                    |  `bool`                                            | `True`                                                                                   | Show logo  |
| `display_infos`                                |  `bool`                                            | `False`                                                                                  | Display additonal information about ISO codes and the NLU namespace structure.|  
| `n_jobs`                                       |          `Optional[int]` | `3`|   `False` | How many cores to use for paralellzing when using Sklearn Dimension Reduction algorithms.  |  




## General Streamlit enhancements

### Support for  [Latent Dirichlet Allocation](https://scikit-learn.org/stable/modules/generated/sklearn.decomposition.LatentDirichletAllocation.html)
The [Latent Dirichlet Allocation](https://scikit-learn.org/stable/modules/generated/sklearn.decomposition.LatentDirichletAllocation.html) algorithm is now supported
for the Word Embedding Visualizations and the Sentence Embedding Visualizations
### Normalization of Vectors before calculating sentence similarity.
WordEmbedding vectors will now be normalized before calculating similarity scores, which bounds each similarity between 0 and 1

### Control order of plots
You can now control the order in Which visualizations appear in the main GUI

### Sentence Embedding Visualization




## Chunk Entity Resolver Training
[Chunk Entity Resolver Training Tutorial Notebook]()
Named Entities are sub pieces in textual data which are labled with classes.    
These classes and strings are still ambious though and it is not possible to group semantically identically entities withouth any definition of `terminology`.
With the `Chunk Resolver` you can train a state of the art deep learning architecture to map entities to their unique terminological representation.

Train a chunk resolver on a dataset with columns named `y` , `_y` and `text`. `y` is a label, `_y` is an extra identifier label, `text` is the raw text

```python
import pandas as pd 
dataset = pd.DataFrame({
    'text': ['The Tesla company is good to invest is', 'TSLA is good to invest','TESLA INC. we should buy','PUT ALL MONEY IN TSLA inc!!'],
    'y': ['23','23','23','23']
    '_y': ['TESLA','TESLA','TESLA','TESLA'], 

})


trainable_pipe = nlu.load('train.resolve_chunks')
fitted_pipe  = trainable_pipe.fit(dataset)
res = fitted_pipe.predict(dataset)
fitted_pipe.predict(["Peter told me to buy Tesla ", 'I have money to loose, is TSLA a good option?'])
```

| entity_resolution_confidence   | entity_resolution_code   | entity_resolution   | document                                      |
|:-------------------------------|:-------------------------|:--------------------|:----------------------------------------------|
| '1.0000'                     | '23]                   | 'TESLA'           | Peter told me to buy Tesla                    |
| '1.0000'                     | '23]                   | 'TESLA'           | I have money to loose, is TSLA a good option? |


### Train with default glove embeddings
```python
untrained_chunk_resolver = nlu.load('train.resolve_chunks')
trained_chunk_resolver  =  untrained_chunk_resolver.fit(df)
trained_chunk_resolver.predict(df)
```

### Train with custom embeddings
```python
# Use BIo GLove
untrained_chunk_resolver = nlu.load('en.embed.glove.biovec train.resolve_chunks')
trained_chunk_resolver  =  untrained_chunk_resolver.fit(df)
trained_chunk_resolver.predict(df)
 ```



## Rule based NER with Context Matcher
[Rule based NER with context matching tutorial notebook](https://github.com/JohnSnowLabs/nlu/blob/master/examples/colab/Training/rule_based_named_entity_recognition_and_resolution/rule_based_NER_and_resolution_with_context_matching.ipynb)    
Define a rule based NER algorithm by providing Regex Patterns and resolution mappings.
The confidence value is computed  using a heuristic approach based on how many matches it has.    
A dictionary can be provided with setDictionary to map extracted entities to a unified representation. The first column of the dictionary file should be the representation with following columns the possible matches.


```python
import nlu
import json
# Define helper functions to write NER rules to file 
"""Generate json with dict contexts at target path"""
def dump_dict_to_json_file(dict, path): 
  with open(path, 'w') as f: json.dump(dict, f)

"""Dump raw text file """
def dump_file_to_csv(data,path):
  with open(path, 'w') as f:f.write(data)
sample_text = """A 28-year-old female with a history of gestational diabetes mellitus diagnosed eight years prior to presentation and subsequent type two diabetes mellitus ( T2DM ), one prior episode of HTG-induced pancreatitis three years prior to presentation , associated with an acute hepatitis , and obesity with a body mass index ( BMI ) of 33.5 kg/m2 , presented with a one-week history of polyuria , polydipsia , poor appetite , and vomiting. Two weeks prior to presentation , she was treated with a five-day course of amoxicillin for a respiratory tract infection . She was on metformin , glipizide , and dapagliflozin for T2DM and atorvastatin and gemfibrozil for HTG . She had been on dapagliflozin for six months at the time of presentation . Physical examination on presentation was significant for dry oral mucosa ; significantly , her abdominal examination was benign with no tenderness , guarding , or rigidity . Pertinent laboratory findings on admission were : serum glucose 111 mg/dl , bicarbonate 18 mmol/l , anion gap 20 , creatinine 0.4 mg/dL , triglycerides 508 mg/dL , total cholesterol 122 mg/dL , glycated hemoglobin ( HbA1c ) 10% , and venous pH 7.27 . Serum lipase was normal at 43 U/L . Serum acetone levels could not be assessed as blood samples kept hemolyzing due to significant lipemia . The patient was initially admitted for starvation ketosis , as she reported poor oral intake for three days prior to admission . However , serum chemistry obtained six hours after presentation revealed her glucose was 186 mg/dL , the anion gap was still elevated at 21 , serum bicarbonate was 16 mmol/L , triglyceride level peaked at 2050 mg/dL , and lipase was 52 U/L . β-hydroxybutyrate level was obtained and found to be elevated at 5.29 mmol/L - the original sample was centrifuged and the chylomicron layer removed prior to analysis due to interference from turbidity caused by lipemia again . The patient was treated with an insulin drip for euDKA and HTG with a reduction in the anion gap to 13 and triglycerides to 1400 mg/dL , within 24 hours . Twenty days ago. Her euDKA was thought to be precipitated by her respiratory tract infection in the setting of SGLT2 inhibitor use . At birth the typical boy is growing slightly faster than the typical girl, but the velocities become equal at about seven months, and then the girl grows faster until four years. From then until adolescence no differences in velocity can be detected. 21-02-2020 21/04/2020 """

# Define Gender NER matching rules
gender_rules = {
    "entity": "Gender",
    "ruleScope": "sentence",
    "completeMatchRegex": "true"    }

# Define dict data in csv format
gender_data = '''male,man,male,boy,gentleman,he,him
female,woman,female,girl,lady,old-lady,she,her
neutral,neutral'''

# Dump configs to file 
dump_dict_to_json_file(gender_data, 'gender.csv')
dump_dict_to_json_file(gender_rules, 'gender.json')
gender_NER_pipe = nlu.load('match.context')
gender_NER_pipe.print_info()
gender_NER_pipe['context_matcher'].setJsonPath('gender.json')
gender_NER_pipe['context_matcher'].setDictionary('gender.csv', options={"delimiter":","})
gender_NER_pipe.predict(sample_text)
```

| context_match | context_match_confidence |
| :------------ | -----------------------: |
| female        |                     0.13 |
| she           |                     0.13 |
| she           |                     0.13 |
| she           |                     0.13 |
| she           |                     0.13 |
| boy           |                     0.13 |
| girl          |                     0.13 |
| girl          |                     0.13 |

### Context Matcher Parameters
You can define the following parameters in your rules.json file to define the entities to be matched

| Parameter             | Type                    | Description                                                  |
| --------------------- | ----------------------- | ------------------------------------------------------------ |
| entity                | `str   `                | The name of this rule                                        |
| regex                 | `Optional[str] `        | Regex Pattern to extract candidates                          |
| contextLength         | `Optional[int] `        | defines the maximum distance a prefix and suffix words can be away from the word to match,whereas context are words that must be immediately after or before the word to match |
| prefix                | `Optional[List[str]] `  | Words preceding the regex match, that are at most `contextLength` characters aways |
| regexPrefix           | `Optional[str]  `       | RegexPattern of words preceding the regex match, that are at most `contextLength` characters aways |
| suffix                | `Optional[List[str]]  ` | Words following the regex match, that are at most `contextLength` characters aways |
| regexSuffix           | `Optional[str] `        | RegexPattern of words following the regex match, that are at most `contextLength` distance aways |
| context               | `Optional[List[str]] `  | list of words that must be immediatly before/after a match   |
| contextException      | `Optional[List[str]] `  | ?? List of words that may not be immediatly before/after a match |
| exceptionDistance     | `Optional[int] `        | Distance exceptions must be away from a match                |
| regexContextException | `Optional[str] `        | Regex Pattern of exceptions that may not be within `exceptionDistance` range of the match |
| matchScope            | `Optional[str]`         | Either `token` or `sub-token` to match on character basis    |
| completeMatchRegex    | `Optional[str]`         | Wether to use complete or partial matching, either `"true"` or `"false"` |
| ruleScope             | `str`                   | currently only `sentence` supported                          |

## Drug Normalizer
[Drug Normalizer tutorial notebook](https://github.com/JohnSnowLabs/nlu/blob/master/examples/colab/healthcare/drug_normalization/drug_norm.ipynb)

Normalize raw text from clinical documents, e.g. scraped web pages or xml document. Removes all dirty characters from text following one or more input regex patterns. Can apply non wanted character removal which a specific policy. Can apply lower case normalization.

**Parameters are**
- lowercase: whether to convert strings to lowercase. Default is False.
- `policy`: rule to remove patterns from text. Valid policy values are: `all` `abbreviations`, `dosages`
  Defaults is `all`. `abbreviation` policy used to expend common drugs abbreviations, `dosages` policy used to convert drugs dosages and values to the standard form (see examples bellow).

```python
data = ["Agnogenic one half cup","adalimumab 54.5 + 43.2 gm","aspirin 10 meq/ 5 ml oral sol","interferon alfa-2b 10 million unit ( 1 ml ) injec","Sodium Chloride/Potassium Chloride 13bag"]
nlu.load('norm_drugs').predict(data)
```


| drug_norm                                            | text                                              |
| :--------------------------------------------------- | :------------------------------------------------ |
| Agnogenic 0.5 oral solution                          | Agnogenic one half cup                            |
| adalimumab 97700 mg                                  | adalimumab 54.5 + 43.2 gm                         |
| aspirin 2 meq/ml oral solution                       | aspirin 10 meq/ 5 ml oral sol                     |
| interferon alfa - 2b 10000000 unt ( 1 ml ) injection | interferon alfa-2b 10 million unit ( 1 ml ) injec |
| Sodium Chloride / Potassium Chloride 13 bag          | Sodium Chloride/Potassium Chloride 13bag          |




## New NLU Spells
These new magical 1-liners which get new the folowing models

### Open Source NLU Spells

| NLU Spell                                                    | Spark NLP Model                                              |
| ------------------------------------------------------------ | ------------------------------------------------------------ |
| [nlu.load('de.ner.wikiner.6B_100')](https://nlp.johnsnowlabs.com//2019/07/13/wikiner_6B_100_de.html) | [wikiner_6B_100](https://nlp.johnsnowlabs.com//2019/07/13/wikiner_6B_100_de.html) |
| nlu.load('xx.embed.glove.glove_6B_100')                      | glove_6B_100                                                 |


### Healthcare NLU spells

| NLU Spell | Spark NLP Model |
| --------- | --------------- |
|[nlu.load('en.resolve.snomed_body_structure_med')](https://nlp.johnsnowlabs.com//2021/06/15/sbertresolve_snomed_bodyStructure_med_en.html)        | [sbertresolve_snomed_bodyStructure_med](https://nlp.johnsnowlabs.com//2021/06/15/sbertresolve_snomed_bodyStructure_med_en.html)
|[nlu.load('en.resolve.snomed_body_structure')](https://nlp.johnsnowlabs.com//2021/06/15/sbiobertresolve_snomed_bodyStructure_en.html)        | [sbiobertresolve_snomed_bodyStructure](https://nlp.johnsnowlabs.com//2021/06/15/sbiobertresolve_snomed_bodyStructure_en.html)
|[nlu.load('en.resolve.icdo_augmented')](https://nlp.johnsnowlabs.com//2021/06/22/sbiobertresolve_icdo_augmented_en.html)        | [sbiobertresolve_icdo_augmented](https://nlp.johnsnowlabs.com//2021/06/22/sbiobertresolve_icdo_augmented_en.html)
|[nlu.load('en.embed_sentence.biobert.jsl_cased')](https://nlp.johnsnowlabs.com//2021/05/14/sbiobert_jsl_cased_en.html)        | [sbiobert_jsl_cased](https://nlp.johnsnowlabs.com//2021/05/14/sbiobert_jsl_cased_en.html)
|[nlu.load('en.embed_sentence.biobert.jsl_umls_cased')](https://nlp.johnsnowlabs.com//2021/05/14/sbiobert_jsl_umls_cased_en.html)        | [sbiobert_jsl_umls_cased](https://nlp.johnsnowlabs.com//2021/05/14/sbiobert_jsl_umls_cased_en.html)
|[nlu.load('en.embed_sentence.bert.jsl_medium_uncased')](https://nlp.johnsnowlabs.com//2021/05/14/sbert_jsl_medium_uncased_en.html)        | [sbert_jsl_medium_uncased](https://nlp.johnsnowlabs.com//2021/05/14/sbert_jsl_medium_uncased_en.html)
|[nlu.load('en.embed_sentence.bert.jsl_medium_umls_uncased')](https://nlp.johnsnowlabs.com//2021/05/14/sbert_jsl_medium_umls_uncased_en.html)        | [sbert_jsl_medium_umls_uncased](https://nlp.johnsnowlabs.com//2021/05/14/sbert_jsl_medium_umls_uncased_en.html)
|[nlu.load('en.embed_sentence.bert.jsl_mini_uncased')](https://nlp.johnsnowlabs.com//2021/05/14/sbert_jsl_mini_uncased_en.html)        | [sbert_jsl_mini_uncased](https://nlp.johnsnowlabs.com//2021/05/14/sbert_jsl_mini_uncased_en.html)
|[nlu.load('en.embed_sentence.bert.jsl_mini_umlsuncased')](https://nlp.johnsnowlabs.com//2021/05/14/sbert_jsl_mini_umls_uncased_en.html)        | [sbert_jsl_mini_umls_uncasedjsl_tiny_uncased](https://nlp.johnsnowlabs.com//2021/05/14/sbert_jsl_mini_umls_uncased_en.html)
|[nlu.load('en.embed_sentence.bert.jsl_tiny_uncased')](https://nlp.johnsnowlabs.com//2021/05/14/sbert_jsl_tiny_uncased_en.html)        | [sbert_jsl_tiny_uncased](https://nlp.johnsnowlabs.com//2021/05/14/sbert_jsl_tiny_uncased_en.html)
|[nlu.load('en.embed_sentence.bert.jsl_tiny_umls_uncased')](https://nlp.johnsnowlabs.com//2021/05/14/sbert_jsl_tiny_umls_uncased_en.html)        | [sbert_jsl_tiny_umls_uncased](https://nlp.johnsnowlabs.com//2021/05/14/sbert_jsl_tiny_umls_uncased_en.html)
|[nlu.load('en.resolve.icd10cm.slim_billable_hcc')](https://nlp.johnsnowlabs.com//2021/05/21/sbiobertresolve_icd10cm_slim_billable_hcc_en.html)        | [sbiobertresolve_icd10cm_slim_billable_hcc](https://nlp.johnsnowlabs.com//2021/05/21/sbiobertresolve_icd10cm_slim_billable_hcc_en.html)
|[nlu.load('en.resolve.icd10cm.slim_billable_hcc_med')](https://nlp.johnsnowlabs.com//2021/05/21/sbertresolve_icd10cm_slim_billable_hcc_med_en.html)        | [sbertresolve_icd10cm_slim_billable_hcc_med](https://nlp.johnsnowlabs.com//2021/05/21/sbertresolve_icd10cm_slim_billable_hcc_med_en.html)
|[nlu.load('med_ner.deid.generic_augmented')](https://nlp.johnsnowlabs.com//2021/06/30/ner_deid_generic_augmented_en.html)        | [ner_deid_generic_augmented](https://nlp.johnsnowlabs.com//2021/06/30/ner_deid_generic_augmented_en.html)
|[nlu.load('med_ner.deid.subentity_augmented')](https://nlp.johnsnowlabs.com//2021/06/30/ner_deid_subentity_augmented_en.html)        | [ner_deid_subentity_augmented](https://nlp.johnsnowlabs.com//2021/06/30/ner_deid_subentity_augmented_en.html)
|[nlu.load('en.assert.radiology')](https://nlp.johnsnowlabs.com//2021/03/18/assertion_dl_radiology_en.html)        | [assertion_dl_radiology](https://nlp.johnsnowlabs.com//2021/03/18/assertion_dl_radiology_en.html)
|[nlu.load('en.relation.test_result_date')](https://nlp.johnsnowlabs.com//2021/02/24/re_test_result_date_en.html)        | [re_test_result_date](https://nlp.johnsnowlabs.com//2021/02/24/re_test_result_date_en.html)
|[nlu.load('en.med_ner.admission_events')](https://nlp.johnsnowlabs.com//2021/03/01/ner_events_admission_clinical_en.html)        | [ner_events_admission_clinical](https://nlp.johnsnowlabs.com//2021/03/01/ner_events_admission_clinical_en.html)
|[nlu.load('en.classify.ade.clinicalbert')](https://nlp.johnsnowlabs.com//2021/01/21/classifierdl_ade_clinicalbert_en.html)        | [classifierdl_ade_clinicalbert](https://nlp.johnsnowlabs.com//2021/01/21/classifierdl_ade_clinicalbert_en.html)
|[nlu.load('en.recognize_entities.posology')](https://nlp.johnsnowlabs.com//2021/03/29/recognize_entities_posology_en.html)        | [recognize_entities_posology](https://nlp.johnsnowlabs.com//2021/03/29/recognize_entities_posology_en.html)
|[nlu.load('en.embed_sentence.bluebert_cased_mli')](TODO.com)        | [spark_name](todo.com)

## Improved NER  defaults
When loading licensed models that require a NER features like  `Assertion`, `Relation`, `Resolution`,
nlu will now use the `en.med_ner` model which maps to the Spark NLP model `jsl_ner_wip_clinical` as default .
See https://nlp.johnsnowlabs.com/2021/03/31/jsl_ner_wip_clinical_en.html for more infos on this model.




## New Notebooks
- [Rule based NER with context matching tutorial notebook](https://github.com/JohnSnowLabs/nlu/blob/master/examples/colab/Training/rule_based_named_entity_recognition_and_resolution/rule_based_NER_and_resolution_with_context_matching.ipynb)
- [Drug Normalizer tutorial notebook](https://github.com/JohnSnowLabs/nlu/blob/master/examples/colab/healthcare/drug_normalization/drug_norm.ipynb)
- [Chunk Entity Resolver Training tutorial notebook](https://github.com/JohnSnowLabs/nlu/blob/master/examples/colab/Training/rchunk_entity_resolution/chunk_entity_resolution_training.ipynb)








# Additional NLU ressources
* [140+ NLU Tutorials](https://github.com/JohnSnowLabs/nlu/tree/master/examples)
* [Streamlit visualizations docs](https://nlu.johnsnowlabs.com/docs/en/streamlit_viz_examples)
* The complete list of all 4000+ models & pipelines in 200+ languages is available on [Models Hub](https://nlp.johnsnowlabs.com/models).
* [Spark NLP publications](https://medium.com/spark-nlp)
* [NLU in Action](https://nlp.johnsnowlabs.com/demo)
* [NLU documentation](https://nlu.johnsnowlabs.com/docs/en/install)
* [Discussions](https://github.com/JohnSnowLabs/spark-nlp/discussions) Engage with other community members, share ideas, and show off how you use Spark NLP and NLU!




### 1 line Install NLU on Google Colab
```!wget https://setup.johnsnowlabs.com/nlu/colab.sh  -O - | bash```
### 1 line Install NLU on Kaggle
```!wget https://setup.johnsnowlabs.com/nlu/kaggle.sh  -O - | bash```
### Install via PIP
```! pip install nlu pyspark==3.0.3```