### PR TITLE
Spark NLP version downgrade

### DIFF
--- a/scripts/colab_setup.sh
+++ b/scripts/colab_setup.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #default values for pyspark, spark-nlp, and SPARK_HOME
-SPARKNLP="4.0.1"
+SPARKNLP="4.0.0"
 PYSPARK="3.2.0"
 NLU="4.0.0"
 

--- a/scripts/kaggle_setup.sh
+++ b/scripts/kaggle_setup.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 #default values for pyspark, spark-nlp, and SPARK_HOME
-SPARKNLP="4.0.1"
+SPARKNLP="4.0.0"
 PYSPARK="3.2.1"
 NLU="4.0.0"
 


### PR DESCRIPTION
`spark-nlp==4.0.1` is not compatible with the latest `spark-nlp-jsl==4.0.0` - I downgraded the colab and kaggle shell scripts to `spark-nlp==4.0.0` to ensure compatibility when using `spark-nlp-jsl` models