### PR TITLE
Making changes for crossplatform paths

### DIFF
--- a/nlu/components/classifiers/named_entity_recognizer_crf/ner_crf.py
+++ b/nlu/components/classifiers/named_entity_recognizer_crf/ner_crf.py
@@ -1,4 +1,5 @@
 from sparknlp.annotator import *
+import os
 
 
 class NERDLCRF:
@@ -23,7 +24,7 @@ class NERDLCRF:
             .setMinEpochs(1) \
             .setMaxEpochs(20) \
             .setLossEps(1e-3) \
-            .setDicts(["ner-corpus/dict.txt"]) \
+            .setDicts([os.path.join("ner-corpus", "dict.txt")]) \
             .setL2(1) \
             .setC0(1250000) \
             .setRandomSeed(0) \

--- a/nlu/info.py
+++ b/nlu/info.py
@@ -125,7 +125,7 @@ class ComponentInfo:
         if not component_info_dir:
             raise ValueError("Calling DatasetInfo.from_directory() with undefined dataset_info_dir.")
         component_info_dir = component_info_dir.replace('//', '/')
-        with open(os.path.join(component_info_dir, COMPONENT_INFO_FILE_NAME), "r") as f:
+        with open(os.path.join(component_info_dir, COMPONENT_INFO_FILE_NAME), "r", encoding="utf8") as f:
             dataset_info_dict = json.load(f)
 
         try:

--- a/nlu/pipe/extractors/extractor_base_data_classes.py
+++ b/nlu/pipe/extractors/extractor_base_data_classes.py
@@ -120,11 +120,11 @@ class SparkNLPExtractorConfig:
     pop_never: bool = field(default=False)  # never ever pop
     meta_black_list: List[str] = field(default=list)
     meta_white_list: List[str] = field(default=list)
-    meta_data_extractor: SparkNLPExtractor = field(default=SparkNLPExtractor())
-    begin_extractor: SparkNLPExtractor = field(default=SparkNLPExtractor())
-    end_extractor: SparkNLPExtractor = field(default=SparkNLPExtractor())
-    result_extractor: SparkNLPExtractor = field(default=SparkNLPExtractor())
-    embedding_extractor: SparkNLPExtractor = field(default=SparkNLPExtractor())
+    meta_data_extractor: SparkNLPExtractor = field(default_factory=SparkNLPExtractor)
+    begin_extractor: SparkNLPExtractor = field(default_factory=SparkNLPExtractor)
+    end_extractor: SparkNLPExtractor = field(default_factory=SparkNLPExtractor)
+    result_extractor: SparkNLPExtractor = field(default_factory=SparkNLPExtractor)
+    embedding_extractor: SparkNLPExtractor = field(default_factory=SparkNLPExtractor)
     description: str = field(default='')
     name: str = field(default='')
 

--- a/nlu/pipe/utils/pipe_utils.py
+++ b/nlu/pipe/utils/pipe_utils.py
@@ -85,7 +85,7 @@ class PipeUtils:
         """Gets the json metadata from a model_anno_obj for a given base path at a specific stage index"""
         c_metadata_path = f'{pipe_path}/stages/{stage_number_as_string}_*/metadata/part-00000'
         c_metadata_path = glob.glob(f'{c_metadata_path}*')[0]
-        with open(c_metadata_path, "r") as f:
+        with open(c_metadata_path, "r", encoding="utf8") as f:
             data = json.load(f)
         return data
 

--- a/nlu/utils/environment/authentication.py
+++ b/nlu/utils/environment/authentication.py
@@ -259,7 +259,7 @@ def auth(HEALTHCARE_LICENSE_OR_JSON_PATH='/content/spark_nlp_for_healthcare.json
 
     if os.path.exists(HEALTHCARE_LICENSE_OR_JSON_PATH):
         # Credentials provided via JSON file
-        with open(HEALTHCARE_LICENSE_OR_JSON_PATH) as json_file:
+        with open(HEALTHCARE_LICENSE_OR_JSON_PATH, encoding="utf8") as json_file:
             j = json.load(json_file)
             if 'SPARK_NLP_LICENSE' in j.keys() and 'SPARK_OCR_LICENSE' in j.keys():
                 # HC and OCR creds provided

--- a/nlu/utils/environment/offline_load_utils.py
+++ b/nlu/utils/environment/offline_load_utils.py
@@ -24,7 +24,7 @@ def is_model(model_path):
 
 def get_model_class(model_path):
     """Extract class from a model_anno_obj saved in model_path"""
-    with open(model_path + '/stages/part-00000') as json_file:
+    with open(model_path + '/stages/part-00000', encoding="utf8") as json_file:
         java_class = json.load(json_file)['class']
         pyth_class = java_class.split('.')[-1]
     return java_class, pyth_class
@@ -36,7 +36,7 @@ def verify_and_create_model(model_path: str):
      Figures out class name by checking metadata json file
      assumes metadata is always called part-00000
     """
-    with open(model_path + '/metadata/' + 'part-00000') as json_f:
+    with open(model_path + '/metadata/' + 'part-00000', encoding="utf8") as json_f:
         class_name = json.load(json_f)['class'].split('.')[-1]
         # The last element in the Class name can be used to just load the model_anno_obj from disk!
         # Just call eval on it, which will give you the actual Python class reference which should have a .load() method
@@ -80,7 +80,7 @@ def test_check_if_string_in_file(file_name, string_to_search, regex=False):
     # print('reading ', file_name)
     import re
 
-    with open(file_name, 'r') as read_obj:
+    with open(file_name, 'r', encoding="utf8") as read_obj:
         # Read all lines in the file one by one
         for line in read_obj:
             # For each line, check if line contains the string

--- a/tests/nlu_core_tests/component_tests/classifier_tests/wav2vec_tests.py
+++ b/tests/nlu_core_tests/component_tests/classifier_tests/wav2vec_tests.py
@@ -24,7 +24,7 @@ class Wav2VecCase(unittest.TestCase):
     def test_wav2vec(self):
         import nlu
         p = nlu.load('en.wav2vec.wip',verbose=True)
-        FILE_PATH = "tests/datasets/audio/asr/ngm_12484_01067234848.wav"
+        FILE_PATH = os.path.normpath(r"tests/datasets/audio/asr/ngm_12484_01067234848.wav")
 
         print("Got p ",p)
         df = p.predict(FILE_PATH)
@@ -34,4 +34,3 @@ class Wav2VecCase(unittest.TestCase):
 
 if __name__ == '__main__':
     unittest.main()
-

--- a/tests/nlu_core_tests/component_tests/matcher_tests/matchers_tests.py
+++ b/tests/nlu_core_tests/component_tests/matcher_tests/matchers_tests.py
@@ -24,7 +24,7 @@ class MatchTests(unittest.TestCase):
         response = urllib2.urlopen("https://wordpress.org/plugins/about/readme.txt")
         data = response.read()
         filename = "readme.txt"
-        file_ = open(filename, "w")
+        file_ = open(filename, "w", encoding="utf8")
         file_.write(data)
         file_.close()
 

--- a/tests/nlu_core_tests/training_tests/classifiers/ner_tests.py
+++ b/tests/nlu_core_tests/training_tests/classifiers/ner_tests.py
@@ -2,6 +2,7 @@ import unittest
 
 import tests.test_utils as t
 from nlu import *
+import os
 
 
 class NerTrainingTests(unittest.TestCase):
@@ -11,7 +12,7 @@ class NerTrainingTests(unittest.TestCase):
         pipe = nlu.load("train.ner", verbose=True)
         pipe = pipe.fit(dataset_path=train_path)
         df = pipe.predict(" Hello Donald Trump and Hello Angela Merkel")
-        pipe.save("saved_test_models/ner_training")
+        pipe.save(os.path.join("saved_test_models", "ner_training"))
         for c in df.columns:
             print(df[c])
 

--- a/tests/nlu_core_tests/training_tests/classifiers/pos_tests.py
+++ b/tests/nlu_core_tests/training_tests/classifiers/pos_tests.py
@@ -26,7 +26,7 @@ class posTrainingTests(unittest.TestCase):
         print(df.columns)
         for c in df.columns:
             print(df[c])
-        p = "saved_test_models/pos_training"
+        p = os.path.join("saved_test_models", "pos_training")
         pipe.save(p)
         # component_list = nlu.load(path=p)
         # df = component_list.predict('Test 123 ')

--- a/tests/nlu_hc_tests/component_tests/contextual_parser/context_parser_tests.py
+++ b/tests/nlu_hc_tests/component_tests/contextual_parser/context_parser_tests.py
@@ -79,7 +79,7 @@ class ContextParserTests(unittest.TestCase):
         """Generate json with dict contexts at target path"""
         import json
 
-        with open(os.path.join(os.path.abspath("./"), path), "w") as f:
+        with open(os.path.join(os.path.abspath("./"), path), "w", encoding="utf8") as f:
             json.dump(dict, f)
 
     def test_dict_dump(self):
@@ -103,6 +103,7 @@ class ContextParserTests(unittest.TestCase):
         with open(
             "gender.csv",
             "w",
+            encoding="utf8",
         ) as f:
             f.write(gender)
 
@@ -116,7 +117,7 @@ class ContextParserTests(unittest.TestCase):
 
         with open(
             "gender.json",
-            "w",
+            "w", encoding="utf8",
         ) as f:
             json.dump(gender, f)
 
@@ -154,7 +155,7 @@ class ContextParserTests(unittest.TestCase):
         contex_pipe["context_matcher"].setJsonPath("gender.json")
         contex_pipe["context_matcher"].setDictionary(
             "gender.csv",
-            read_as=ReadAs.TEXT,
+            read_as="TEXT",
             options={"delimiter": ","},
         )
 

--- a/tests/nlu_hc_tests/verification_tests.py
+++ b/tests/nlu_hc_tests/verification_tests.py
@@ -42,7 +42,7 @@ class TestAuthentification(unittest.TestCase):
     def test_auth_via_file(self):
         secrets_json_path = os.path.join(os.path.abspath("./"), "license.json")
         print("license path:", secrets_json_path)
-        with open(secrets_json_path, "w") as file:
+        with open(secrets_json_path, "w", encoding="utf8") as file:
             json.dump(sct.license_dict, file)
         res = (
             nlu.auth(secrets_json_path)


### PR DESCRIPTION
- I added `encoding="utf8"` on the `open` statements. 
- I wrapped paths with `os.path.join` or equivalent in many places
- I changed the `@dataclass` definition of some parameters to use `default_factory` instead of `default` when the values were mutable (using the class `SparkNLPExtractor`). I did this as I got an error when installing the `nlu` library from `johnsnowlabs`.
- `ReadAs` was not imported, so I changed to the `"TEXT"`  in the `test_context_parser`.